### PR TITLE
Unsubscribe user from MobileCommons Service

### DIFF
--- a/app/Aurora/NorthstarUser.php
+++ b/app/Aurora/NorthstarUser.php
@@ -141,4 +141,9 @@ class NorthstarUser {
     return $unassigned_roles;
   }
 
+  public function unsubscribeFromMobileCommons() {
+    $mobile = $this->profile['mobile'];
+    return $this->mobileCommons->unsubscribeUser($mobile);
+  }
+
 }

--- a/app/Aurora/Services/MobileCommons.php
+++ b/app/Aurora/Services/MobileCommons.php
@@ -35,11 +35,7 @@ class MobileCommonsAPI {
   {
     $response = $this->client->get('?phone_number=' . $mobile . '&include_messages=true');
 
-    $xml = $response->xml();
-
-    $json = json_encode($xml);
-
-    $array = json_decode($json, TRUE);
+    $array = xmlToJson($response);
 
     if (empty($array['error'])){
       return array_filter($array['profile']);
@@ -76,11 +72,7 @@ class MobileCommonsAPI {
       'body' => array("phone_number" => $mobile)
       ]);
 
-      $xml = $response->xml();
-
-      $json = json_encode($xml);
-
-      $array = json_decode($json, TRUE);
+      $array = xmlToJson($response);
 
       if ($array['@attributes']['success'] === 'true') {
         return $array['@attributes']['success'];

--- a/app/Aurora/Services/MobileCommons.php
+++ b/app/Aurora/Services/MobileCommons.php
@@ -62,4 +62,30 @@ class MobileCommonsAPI {
       return [];
     }
   }
+
+
+  /**
+   * Send a POST request to unsubscribe user from MC
+   *
+   * @param String mobile number
+   * @return String Response
+   */
+  public function unsubscribeUser($mobile)
+  {
+    $response = $this->client->post('profile_opt_out', [
+      'body' => array("phone_number" => $mobile)
+      ]);
+
+      $xml = $response->xml();
+
+      $json = json_encode($xml);
+
+      $array = json_decode($json, TRUE);
+
+      if ($array['@attributes']['success'] === 'true') {
+        return $array['@attributes']['success'];
+      } else {
+        return $array['error']['@attributes']['message'];
+      }
+  }
 }

--- a/app/Aurora/helpers.php
+++ b/app/Aurora/helpers.php
@@ -152,3 +152,9 @@ function config($var)
  return \Config::get($var);
 }
 
+function  xmlToJson($response)
+{
+  $xml = $response->xml();
+  $json = json_encode($xml);
+  return json_decode($json, TRUE);
+}

--- a/app/controllers/UsersController.php
+++ b/app/controllers/UsersController.php
@@ -270,4 +270,24 @@ class UsersController extends \BaseController {
       $this->northstar->deleteUser($id);
     }
   }
+
+
+  /**
+   * Unsubscribe from Mobile Commons Service
+   *
+   * @param String Mobile
+   * @return Response
+   */
+   public function unsubscribeMC($id)
+   {
+    $northstar_user = new NorthstarUser($id);
+    $response = $northstar_user->unsubscribeFromMobileCommons();
+
+    if ($response == 'true') {
+      return Redirect::route('users.show', $id)->with('flash_message', ['class' => 'messages', 'text' => 'Unsubscribed from MobileCommons service']);
+    } else {
+      return Redirect::route('users.show', $id)->with('flash_message', ['class' => 'messages -error', 'text' => $response]);
+    }
+   }
+
 }

--- a/app/routes.php
+++ b/app/routes.php
@@ -56,3 +56,6 @@ Route::get('/advanced-search', 'UsersController@advancedSearch');
 
 # Unauthorized Page
 Route::get('/unauthorized', 'SessionsController@unauthorized');
+
+# Unsubscribe from MobileCommons
+Route::post('unsubscribeMC/{id}', ['as' => 'users.unsubscribeMC', 'uses' => 'UsersController@unsubscribeMC']);

--- a/app/views/users/partials/details.blade.php
+++ b/app/views/users/partials/details.blade.php
@@ -21,6 +21,16 @@
 			<div class="container -padded">
 				@if(Auth::user()->hasRole('admin'))
 	        @include('users.partials.assign-role')
+					<!-- Mobile Commons Status -->
+
+					@if(!empty($mobile_commons_profile))
+						@if($mobile_commons_profile['status'] === "Active Subscriber")
+						{{ Form::open(['route' => array('users.unsubscribeMC', $northstar_profile['_id'])]) }}
+							{{ Form::submit('Unsubscribe', ['name' => 'type', 'class' => 'button -secondary']) }}
+						{{ Form::close() }}
+						@endif
+					@endif
+
 				@endif
 		</article>
 	</li>

--- a/app/views/users/partials/details.blade.php
+++ b/app/views/users/partials/details.blade.php
@@ -1,6 +1,6 @@
-<ul class="gallery -duo">
+<ul class="gallery -triad">
 	<li>
-		<article class="figure -left">
+		<div class="figure">
 			<dl class="profile-settings">
 				<dt>Id:</dt><dd>{{{ $northstar_profile['_id'] }}}</dd>
 				{{ isset($northstar_profile['drupal_id']) ? ('<dt>Drupal Id:</dt><dd>' . e($northstar_profile['drupal_id']) . '</dd>') : "" }}
@@ -14,24 +14,33 @@
 				@endif
 				{{ isset($northstar_profile['country']) ? ('<dt>Country:</dt><dd>' . e($northstar_profile['country']) . '</dd>') : "" }}
 			</dl>
-		</article>
+		</div>
 	</li>
 	<li>
-		<article class="figure -left">
+		<div class="figure">
 			<div class="container -padded">
 				@if(Auth::user()->hasRole('admin'))
 	        @include('users.partials.assign-role')
-					<!-- Mobile Commons Status -->
-
-					@if(!empty($mobile_commons_profile))
+				@endif
+		</div>
+	</li>
+	<li>
+		<div class="figure">
+			<div class="container -padded">
+				<div class="subscription-header">
+					Subscriptions
+				</div>
+				<div class="container__block subscription-container">
+					@if(Auth::user()->hasRole('admin') && !empty($mobile_commons_profile))
 						@if($mobile_commons_profile['status'] === "Active Subscriber")
 						{{ Form::open(['route' => array('users.unsubscribeMC', $northstar_profile['_id'])]) }}
+							{{ Form::label("Mobile Commons") }}
 							{{ Form::submit('Unsubscribe', ['name' => 'type', 'class' => 'button -secondary']) }}
 						{{ Form::close() }}
 						@endif
 					@endif
-
-				@endif
-		</article>
+				</div>
+			</div>
+		</div>
 	</li>
 </ul>

--- a/app/views/users/partials/unsubscribe.blade.php
+++ b/app/views/users/partials/unsubscribe.blade.php
@@ -6,17 +6,18 @@
 	<!-- Unsubscribe User from Mobile Commons -->
 	@if(!empty($mobile_commons_profile))
 		@if($mobile_commons_profile['status'] === "Active Subscriber")
-		{{ Form::open(['route' => array('users.unsubscribe-mobilecommons', $northstar_profile['_id']), 'method' => 'delete']) }}
+			{{ Form::open(['route' => array('users.unsubscribe-mobilecommons', $northstar_profile['_id']), 'method' => 'delete']) }}
 			{{ Form::label('', "MobileCommons", ['class' => 'field-label']) }}
 			{{ Form::submit('Unsubscribe', ['name' => 'type', 'class' => 'button -secondary']) }}
-		{{ Form::close() }}
+			{{ Form::close() }}
 		@else
 			<h4>This user does not have a MobileCommons subscription</h4>
 		@endif
 	@endif
+
 	<!-- Unsubscribe User to MailChimp -->
 	@if (!empty($mailchimp_list_id))
-		{{ Form::model($northstar_profile, ['route' => array('users.unsubscribe-mailchimp', $northstar_profile['_id'], 'mailchimp_list_id' => $mailchimp_list_id), 'method' => 'delete']) }}
+		{{ Form::open(['route' => array('users.unsubscribe-mailchimp', $northstar_profile['_id'], 'mailchimp_list_id' => $mailchimp_list_id), 'method' => 'delete']) }}
 		{{ Form::label('', "MailChimp", ['class' => 'field-label']) }}
 		{{ Form::submit('Unsubscribe', ['name' => 'type', 'class' => 'button -secondary']) }}
 		{{ Form::close() }}

--- a/public/assets/custom-neue.css
+++ b/public/assets/custom-neue.css
@@ -155,3 +155,17 @@
 #advanced-search-container {
   display: none;
 }
+
+.subscription-container{
+  border: 1px solid black;
+  line-height: 200%;
+  border-radius: 0 0 5px 5px;
+}
+.subscription-header {
+  font-weight: 900;
+  color: #ffffff ;
+  background: red ;
+  padding: 9px 10px 10px;
+  border: 1px solid black;
+  border-radius: 5px 5px 0 0;
+}


### PR DESCRIPTION
# What's this PR do?
* Ability to unsubscribe user from MobileCommons service if the user is an `active subscriber`.
* Changing styling `users/partials/details` from gallery `-duo` to `triad`. Making unsubscription services their own section.

# Where should the reviewer start?

UsersController.php
MobileCommons.php

# Any related ticket?
*  #104 Opt out users from communications

CC: @angaither @DFurnes 