### PR TITLE
Mobile Commons opt_in_path_link

### DIFF
--- a/app/Aurora/Services/MobileCommons.php
+++ b/app/Aurora/Services/MobileCommons.php
@@ -33,7 +33,7 @@ class MobileCommonsAPI {
    */
   public function userProfile($mobile)
   {
-    $response = $this->client->get('?phone_number=' . 6466675480 . '&include_messages=true');
+    $response = $this->client->get('?phone_number=' . $mobile . '&include_messages=true');
 
     $xml = $response->xml();
 

--- a/app/Aurora/Services/MobileCommons.php
+++ b/app/Aurora/Services/MobileCommons.php
@@ -33,7 +33,7 @@ class MobileCommonsAPI {
    */
   public function userProfile($mobile)
   {
-    $response = $this->client->get('?phone_number=' . $mobile . '&include_messages=true');
+    $response = $this->client->get('?phone_number=' . 6466675480 . '&include_messages=true');
 
     $xml = $response->xml();
 

--- a/app/controllers/UsersController.php
+++ b/app/controllers/UsersController.php
@@ -91,12 +91,10 @@ class UsersController extends \BaseController {
     $northstar_user = new NorthstarUser($id);
     $profile = $northstar_user->getMobileCommonsProfile();
     $messages = $northstar_user->getMobileCommonsMessages();
-    // dd($profile['subscriptions']['subscription']);
     foreach ($profile['subscriptions']['subscription'] as $subscription){
-      $subscriptions[$subscription['@attributes']['campaign_id']][] = $subscription['@attributes']['opt_in_path_id'];
+      $opt_in_path_ids[$subscription['@attributes']['campaign_id']][] = $subscription['@attributes']['opt_in_path_id'];
     }
-
-    return View::make('users.mobile-commons-messages')->with(compact('messages', 'subscriptions'));
+    return View::make('users.mobile-commons-messages')->with(compact('messages', 'opt_in_path_ids'));
   }
 
 

--- a/app/controllers/UsersController.php
+++ b/app/controllers/UsersController.php
@@ -89,10 +89,14 @@ class UsersController extends \BaseController {
   public function mobileCommonsMessages($id)
   {
     $northstar_user = new NorthstarUser($id);
+    $profile = $northstar_user->getMobileCommonsProfile();
+    $messages = $northstar_user->getMobileCommonsMessages();
+    // dd($profile['subscriptions']['subscription']);
+    foreach ($profile['subscriptions']['subscription'] as $subscription){
+      $subscriptions[$subscription['@attributes']['campaign_id']][] = $subscription['@attributes']['opt_in_path_id'];
+    }
 
-    $mobile_commons_messages = $northstar_user->getMobileCommonsMessages();
-
-    return View::make('users.mobile-commons-messages')->with(compact('mobile_commons_messages'));
+    return View::make('users.mobile-commons-messages')->with(compact('messages', 'subscriptions'));
   }
 
 

--- a/app/views/users/mobile-commons-messages.blade.php
+++ b/app/views/users/mobile-commons-messages.blade.php
@@ -34,15 +34,16 @@
 				  			<div class="container__block">
 					  			<dl class="profile-settings">
 							  		<dt>Content: </dt><dd>{{{ !empty($message['body']) ? $message['body'] : "" }}}</dd>
-                    @if ($message['@attributes']['status'] != 'failed_permanently' && $message['@attributes']['status'] != 'sent' )
-                      @if (!empty($subscriptions[$campaign['@attributes']['id']] ))
+                    <!-- if ($message['@attributes']['status'] != 'failed_permanently' && $message['@attributes']['status'] != 'sent' ) -->
+                    <!-- conditional above is to make opt_in_path_link to MobileCommons only appear for user sent messages -->
+                      @if (!empty($opt_in_path_ids[$campaign['@attributes']['id']] ))
                       <dt>Involved Opt In Path Id:</dt>
-                      <?php $campaign_id = array_search($subscriptions[$campaign['@attributes']['id']], $subscriptions)?>
-                        @foreach( $subscriptions[$campaign['@attributes']['id']] as $opt_in_path_id )
+                      <?php $campaign_id = array_search($opt_in_path_ids[$campaign['@attributes']['id']], $opt_in_path_ids)?>
+                        @foreach( array_unique($opt_in_path_ids[$campaign['@attributes']['id']]) as $opt_in_path_id )
                           <dt>{{  link_to('https://secure.mcommons.com/campaigns/'. $campaign_id . '/opt_in_paths/' . $opt_in_path_id, $opt_in_path_id)  }}</dt>
                         @endforeach
                       @endif
-                    @endif
+                    <!-- endif -->
 					  			</dl>
 				  			</div>
 			  			</article>

--- a/app/views/users/mobile-commons-messages.blade.php
+++ b/app/views/users/mobile-commons-messages.blade.php
@@ -7,7 +7,7 @@
 <div class ="container -padded">
   <div class="wrapper">
 	  <div class="container__block">
-	  	@forelse($mobile_commons_messages as $message)
+	  	@forelse($messages as $message)
 				<div class="mobile-commons-message {{ message_state_class($message['@attributes']['status']) }}" >
 			  	<ul class="gallery -duo">
 			  		<li>
@@ -16,9 +16,14 @@
 									<dl class="profile-settings">
 							  		<dt>Status: </dt><dd>{{{ $message['@attributes']['status'] }}}</dd>
 							  		<dt>Message Type:	</dt><dd>{{{ $message['@attributes']['message_type'] }}}</dd>
-							  		<dt>Campaign: </dt><dd><a href="https://secure.mcommons.com/campaigns/{{{ $message['campaign']['@attributes']['id'] }}}">{{{ $message['campaign']['name'] }}}</a></dd>
-							  		<dt>Campaign ID: </dt><dd>{{{ $message['campaign']['@attributes']['id'] }}}</dd>
-							  		<dt>Active?: </dt><dd>{{{ $message['campaign']['@attributes']['active'] }}}</dd>
+                     @If(isset($message['campaign']))
+                    <?php $campaign = $message['campaign'] ?>
+                    @else
+                    <?php $campaign = $message['mdata'] ?>
+                    @endif
+							  		<dt>Campaign: </dt><dd>{{ link_to('https://secure.mcommons.com/campaigns/' . $campaign['@attributes']['id'], $campaign['name']) }}</dd>
+							  		<dt>Campaign ID: </dt><dd>{{{ $campaign['@attributes']['id'] }}}</dd>
+							  		<dt>Active?: </dt><dd>{{{ $campaign['@attributes']['active'] }}}</dd>
 							  		<dt>Sent On: </dt><dd>{{{ time_formatter($message['when']), true }}}</dd>
 									</dl>
 					  		</div>
@@ -28,7 +33,16 @@
 			  			<article class="figure -left">
 				  			<div class="container__block">
 					  			<dl class="profile-settings">
-							  		<dt>Content: </dt><dd>{{{ $message['body'] }}}</dd>
+							  		<dt>Content: </dt><dd>{{{ !empty($message['body']) ? $message['body'] : "" }}}</dd>
+                    @if ($message['@attributes']['status'] != 'failed_permanently' && $message['@attributes']['status'] != 'sent' )
+                      @if (!empty($subscriptions[$campaign['@attributes']['id']] ))
+                      <dt>Involved Opt In Path Id:</dt>
+                      <?php $campaign_id = array_search($subscriptions[$campaign['@attributes']['id']], $subscriptions)?>
+                        @foreach( $subscriptions[$campaign['@attributes']['id']] as $opt_in_path_id )
+                          <dt>{{  link_to('https://secure.mcommons.com/campaigns/'. $campaign_id . '/opt_in_paths/' . $opt_in_path_id, $opt_in_path_id)  }}</dt>
+                        @endforeach
+                      @endif
+                    @endif
 					  			</dl>
 				  			</div>
 			  			</article>


### PR DESCRIPTION
# What's this PR do?
* This PR probably shouldn't be merged?
* To be able to see in MobileCommons site which opt_in actions being triggered in the conversation with users from Mobile Commons service.
* Reference for future development related with **Mobile Commons messages**

# Where should the reviewer start?
UsersController.php -> `mobileCommonsMessages` where I include a variable containing all the ids of `campaign_id => opt_in_path_ids` and make a link to MobileCommons page where ithe message is *probably* related to the opt_in action trigged.

___
*Is it ready?*
I'm catching `campaings_id` and `opt_in_path_id` from `user subscription` attributes from `https://mobilecommons.zendesk.com/hc/en-us/articles/202052534-REST-API#ProfileSummary`

Its good enough to see what triggers the conversation in general and sometimes it can be unrelated, because MobileCommons API doesnt support opt_in_id in every messages explicitly.

We are waiting to see what MC could do with this to help providing us with more related opt_in_ids that being triggered by every messages.

# What's related ticket?
 References #108 

___
CC: @jonuy @angaither 

