### PR TITLE
Route model binding

### DIFF
--- a/app/APIResponseCollection.php
+++ b/app/APIResponseCollection.php
@@ -35,6 +35,7 @@ class APIResponseCollection extends Collection
     /**
      * Set the base path for the paginator.
      * @param $path
+     * @return self
      */
     public function setPaginationPath($path)
     {
@@ -46,6 +47,7 @@ class APIResponseCollection extends Collection
     /**
      * Append a query string to pagination links.
      * @param array $query
+     * @return self
      */
     public function appendPaginationQuery($query)
     {

--- a/app/APIResponseModel.php
+++ b/app/APIResponseModel.php
@@ -42,6 +42,15 @@ class APIResponseModel
     const UPDATED_AT = 'updated_at';
 
     /**
+     * Create a new API response model.
+     * @param $attributes
+     */
+    public function __construct($attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    /**
      * Determine if an attribute exists on the model.
      *
      * @param  string  $key

--- a/app/Http/Controllers/AuroraUsersController.php
+++ b/app/Http/Controllers/AuroraUsersController.php
@@ -49,15 +49,12 @@ class AuroraUsersController extends Controller
     /**
      * Display the form for editing user information
      *
-     * @param  string  $id
+     * @param AuroraUser $auroraUser
      * @return \Illuminate\Http\Response
      */
-    public function edit($id)
+    public function edit(AuroraUser $auroraUser)
     {
-        $auroraUser = User::where('id', $id)->firstOrFail();
-
-        // Get the list of all roles
-        $roles = User::allRoles();
+        $roles = AuroraUser::allRoles();
 
         return view('aurora-users.edit')->with(compact('auroraUser', 'roles'));
     }
@@ -65,12 +62,12 @@ class AuroraUsersController extends Controller
     /**
      * Update the user's Aurora profile.
      *
+     * @param AuroraUser $auroraUser
      * @param Request $request
      * @return \Illuminate\Http\Response
      */
-    public function update($id, Request $request)
+    public function update(AuroraUser $auroraUser, Request $request)
     {
-        $auroraUser = User::where('id', $id)->firstOrFail();
         $auroraUser->fill($request->all());
 
         $auroraUser->save();

--- a/app/Http/Controllers/AuroraUsersController.php
+++ b/app/Http/Controllers/AuroraUsersController.php
@@ -2,7 +2,7 @@
 
 namespace Aurora\Http\Controllers;
 
-use Aurora\Models\User;
+use Aurora\Models\AuroraUser;
 use Aurora\Services\Northstar;
 use Illuminate\Http\Request;
 
@@ -29,12 +29,12 @@ class AuroraUsersController extends Controller
     public function index()
     {
         $users = [
-            'admin' => User::where('role', 'admin')->get(),
-            'staff' => User::where('role', 'staff')->get(),
-            'intern' => User::where('role', 'intern')->get(),
+            'admin' => AuroraUser::where('role', 'admin')->get(),
+            'staff' => AuroraUser::where('role', 'staff')->get(),
+            'intern' => AuroraUser::where('role', 'intern')->get(),
 
             // Users that have tried to sign in but has no role assigned.
-            'unauthorized' => User::where('role', '')->get(),
+            'unauthorized' => AuroraUser::where('role', '')->get(),
         ];
 
         foreach ($users as $role => $subsetUsers) {

--- a/app/Http/Controllers/KeyController.php
+++ b/app/Http/Controllers/KeyController.php
@@ -2,6 +2,7 @@
 
 namespace Aurora\Http\Controllers;
 
+use Aurora\NorthstarKey;
 use Aurora\Services\Northstar;
 use Illuminate\Http\Request;
 
@@ -24,7 +25,7 @@ class KeyController extends Controller
      * Display a listing of the resource.
      * GET /keys
      *
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function index()
     {
@@ -37,12 +38,11 @@ class KeyController extends Controller
      * Show key details.
      * GET /keys/:api_key
      *
+     * @param NorthstarKey $key
      * @return \Illuminate\Http\Response
      */
-    public function show($api_key)
+    public function show(NorthstarKey $key)
     {
-        $key = $this->northstar->getApiKey($api_key);
-
         return view('keys.show')->with(compact('key'));
     }
 
@@ -77,11 +77,11 @@ class KeyController extends Controller
      * Edit key details.
      * GET /keys/:api_key/edit
      *
+     * @param NorthstarKey $key
      * @return \Illuminate\Http\Response
      */
-    public function edit($api_key)
+    public function edit(NorthstarKey $key)
     {
-        $key = $this->northstar->getApiKey($api_key);
         $scopes = $this->northstar->scopes();
 
         return view('keys.edit')->with(compact('key', 'scopes'));
@@ -91,25 +91,27 @@ class KeyController extends Controller
      * Update an existing key's details.
      * PUT /keys/:api_key
      *
+     * @param NorthstarKey $key
      * @param Request $request
      * @return \Illuminate\Http\Response
      */
-    public function update($api_key, Request $request)
+    public function update(NorthstarKey $key, Request $request)
     {
-        $this->northstar->updateApiKey($api_key, $request->all());
+        $this->northstar->updateApiKey($key->api_key, $request->all());
 
-        return redirect()->route('keys.index')->with('flash_message', ['class' => 'messages', 'text' => 'Cool, new app added!']);
+        return redirect()->route('keys.index')->with('flash_message', ['class' => 'messages', 'text' => 'Cool, saved those changes!']);
     }
 
     /**
      * Destroy an existing key.
      * DELETE /keys/:api_key
      *
+     * @param NorthstarKey $key
      * @return \Illuminate\Http\Response
      */
-    public function destroy($api_key)
+    public function destroy(NorthstarKey $key)
     {
-        $deleted = $this->northstar->deleteApiKey($api_key);
+        $deleted = $this->northstar->deleteApiKey($key->api_key);
 
         if (! $deleted) {
             return redirect()->route('keys.index')->with('flash_message', ['class' => 'messages -error', 'text' => 'Could not delete key.']);

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -2,7 +2,8 @@
 
 namespace Aurora\Http\Controllers;
 
-use Aurora\Models\User;
+use Aurora\Models\AuroraUser;
+use Aurora\NorthstarUser;
 use Aurora\Services\Northstar;
 use Illuminate\Http\Request;
 
@@ -37,13 +38,12 @@ class UsersController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  string  $id
+     * @param NorthstarUser $user
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(NorthstarUser $user)
     {
-        $user = $this->northstar->getUser('_id', $id);
-        $auroraUser = User::where('northstar_id', $user->id)->first();
+        $auroraUser = AuroraUser::where('northstar_id', $user->id)->first();
 
         //Calling other APIs related to the user.
         $campaigns = $user->getCampaigns();

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -1,48 +1,27 @@
 <?php
 
-/*
-|--------------------------------------------------------------------------
-| Application Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register all of the routes for an application.
-| It's a breeze. Simply tell Laravel the URIs it should respond to
-| and give it the controller to call when that URI is requested.
-|
-*/
+/**
+ * Set routes for the application.
+ *
+ * @var \Illuminate\Routing\Router $router
+ * @see \Northstar\Providers\RouteServiceProvider
+ */
 
-Route::get('/', function () {
+$router->get('/', function () {
     return redirect()->route('users.index');
 });
 
 // Authentication
-Route::get('auth/login', 'Auth\AuthController@getLogin');
-Route::post('auth/login', 'Auth\AuthController@postLogin');
-Route::get('auth/logout', 'Auth\AuthController@getLogout');
+$router->get('auth/login', 'Auth\AuthController@getLogin');
+$router->post('auth/login', 'Auth\AuthController@postLogin');
+$router->get('auth/logout', 'Auth\AuthController@getLogout');
 
 // Users
-Route::resource('users', 'UsersController', ['except' => ['create', 'store']]);
+$router->resource('users', 'UsersController', ['except' => ['create', 'store']]);
+$router->get('search', ['as' => 'user.search', 'uses' => 'UsersController@search']);
 
 // Aurora Users
-Route::resource('aurora-users', 'AuroraUsersController', ['only' => ['index', 'edit', 'update']]);
-
-// Delete Northstar User
-Route::delete('northstar-user-delete/{user}', ['as' => 'northstar.delete', 'uses' => 'UsersController@deleteNorthstarUser']);
-
-// Display edit form with merged users
-Route::get('merge', ['as' => 'users.merge', 'uses' => 'UsersController@mergedForm']);
-
-// Delete other users that were not selected
-Route::post('merge', ['as' => 'users.merge-and-delete', 'uses' => 'UsersController@deleteUnmergedUsers']);
-
-// Create admins.
-Route::post('role/{user}', ['as' => 'role.create', 'uses' => 'UsersController@roleCreate']);
+$router->resource('aurora-users', 'AuroraUsersController', ['only' => ['index', 'edit', 'update']]);
 
 // Key
-Route::resource('keys', 'KeyController');
-
-// Search
-Route::get('search', ['as' => 'users.search', 'uses' => 'UsersController@search', 'before' => 'auth']);
-
-// Advanced Search
-Route::get('/advanced-search', 'UsersController@advancedSearch');
+$router->resource('keys', 'KeyController');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -7,6 +7,7 @@
  * @see \Northstar\Providers\RouteServiceProvider
  */
 
+// Redirect to the users index from the homepage
 $router->get('/', function () {
     return redirect()->route('users.index');
 });

--- a/app/NorthstarKey.php
+++ b/app/NorthstarKey.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Aurora;
+
+class NorthstarKey extends APIResponseModel
+{
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = ['created_at', 'updated_at'];
+}

--- a/app/NorthstarUser.php
+++ b/app/NorthstarUser.php
@@ -11,12 +11,6 @@ class NorthstarUser extends APIResponseModel
     protected $drupal;
 
     /**
-     * Raw profile data from Northstar.
-     * @var array
-     */
-    protected $attributes;
-
-    /**
      * The attributes that should be cast to native types.
      *
      * @var array
@@ -34,7 +28,7 @@ class NorthstarUser extends APIResponseModel
     {
         $this->drupal = app('Aurora\Services\Drupal');
 
-        $this->attributes = $attributes;
+        parent::__construct($attributes);
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,11 +2,9 @@
 
 namespace Aurora\Providers;
 
-use Aurora\Services\Northstar;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Routing\Router;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
-use Mockery\CountValidator\Exception;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RouteServiceProvider extends ServiceProvider
@@ -31,8 +29,9 @@ class RouteServiceProvider extends ServiceProvider
         $router->bind('users', function ($id) {
             try {
                 $user = app('\Aurora\Services\Northstar')->getUser('_id', $id);
+
                 return $user;
-            } catch(ClientException $e) {
+            } catch (ClientException $e) {
                 throw new NotFoundHttpException;
             }
         });
@@ -40,8 +39,9 @@ class RouteServiceProvider extends ServiceProvider
         $router->bind('keys', function ($id) {
             try {
                 $key = app('\Aurora\Services\Northstar')->getApiKey($id);
+
                 return $key;
-            } catch(ClientException $e) {
+            } catch (ClientException $e) {
                 throw new NotFoundHttpException;
             }
         });

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,8 +2,12 @@
 
 namespace Aurora\Providers;
 
+use Aurora\Services\Northstar;
+use GuzzleHttp\Exception\ClientException;
 use Illuminate\Routing\Router;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Mockery\CountValidator\Exception;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -24,7 +28,25 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot(Router $router)
     {
-        //
+        $router->bind('users', function ($id) {
+            try {
+                $user = app('\Aurora\Services\Northstar')->getUser('_id', $id);
+                return $user;
+            } catch(ClientException $e) {
+                throw new NotFoundHttpException;
+            }
+        });
+
+        $router->bind('keys', function ($id) {
+            try {
+                $key = app('\Aurora\Services\Northstar')->getApiKey($id);
+                return $key;
+            } catch(ClientException $e) {
+                throw new NotFoundHttpException;
+            }
+        });
+
+        $router->model('aurora-users', '\Aurora\Models\AuroraUser');
 
         parent::boot($router);
     }

--- a/app/Services/Northstar.php
+++ b/app/Services/Northstar.php
@@ -3,6 +3,7 @@
 namespace Aurora\Services;
 
 use Aurora\APIResponseCollection;
+use Aurora\NorthstarKey;
 use Aurora\NorthstarUser;
 use GuzzleHttp\Client;
 
@@ -101,8 +102,9 @@ class Northstar
     public function getApiKey($api_key)
     {
         $response = $this->client->get('keys/'.$api_key);
+        $key = new NorthstarKey($response->json()['data']);
 
-        return $response->json()['data'];
+        return $key;
     }
 
     public function deleteApiKey($api_key)
@@ -124,8 +126,9 @@ class Northstar
         $response = $this->client->post('keys', [
             'body' => json_encode($input),
         ]);
+        $key = new NorthstarKey($response->json()['data']);
 
-        return $response->json();
+        return $key;
     }
 
     /**
@@ -140,7 +143,9 @@ class Northstar
             'body' => json_encode($input),
         ]);
 
-        return $response->json();
+        $key = new NorthstarKey($response->json()['data']);
+
+        return $key;
     }
 
     /**

--- a/app/models/AuroraUser.php
+++ b/app/models/AuroraUser.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 
-class User extends Model implements AuthenticatableContract
+class AuroraUser extends Model implements AuthenticatableContract
 {
     use Authenticatable;
 
@@ -43,7 +43,7 @@ class User extends Model implements AuthenticatableContract
      */
     public function northstarUser()
     {
-        return $this->northstar->getUser('_id', $this->northstar_id);
+        return app('\Aurora\Services\Northstar')->getUser('_id', $this->northstar_id);
     }
 
     /**

--- a/config/auth.php
+++ b/config/auth.php
@@ -28,7 +28,7 @@ return [
     |
     */
 
-    'model' => Aurora\Models\User::class,
+    'model' => Aurora\Models\AuroraUser::class,
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2016_01_20_194715_update_users_table.php
+++ b/database/migrations/2016_01_20_194715_update_users_table.php
@@ -21,7 +21,7 @@ class UpdateUsersTable extends Migration
         // Translate existing relations to plain column value
         $roleMapping = DB::table('roles')->join('role_user', 'role_user.role_id', '=', 'roles.id')->select('role_user.user_id', 'roles.name')->get();
         foreach ($roleMapping as $mapping) {
-            $user = \Aurora\Models\User::find($mapping->user_id);
+            $user = \Aurora\Models\AuroraUser::find($mapping->user_id);
             $user->role = $mapping->name;
             $user->save();
         }

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,24 @@
+@extends('layout.master')
+
+@section('main_content')
+
+    @include('layout.header', ["header" => "Not Found", "subtitle" => "We couldn't find that thing."])
+
+    <div class="container -padded">
+        <div class="wrapper">
+            <div class="container__block -narrow">
+                <h1>Hmmm, what happened?</h1>
+                <p>If you followed a link from within Aurora, please
+                    <a href="https://github.com/DoSomething/aurora/issues/new">report an issue</a> and we'll try to
+                    figure out what might have went wrong. If you followed a link from elsewhere, perhaps the thing
+                    you were looking for has been deleted?</p>
+                <p>Well, either way&hellip; it's not here.</p>
+            </div>
+
+            <div class="container__block -narrow">
+                <h3>Perhaps a search will help?</h3>
+                @include('search.search')
+            </div>
+        </div>
+    </div>
+@stop

--- a/resources/views/keys/edit.blade.php
+++ b/resources/views/keys/edit.blade.php
@@ -7,23 +7,23 @@
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block -narrow">
-                <h1>{{ $key['app_id'] }}</h1>
-                {!! Form::open(['route' => ['keys.update', $key['api_key']], 'method' => 'PUT']) !!}
+                <h1>{{ $key->app_id }}</h1>
+                {!! Form::open(['route' => ['keys.update', $key->api_key], 'method' => 'PUT']) !!}
                     <div class="form-item -padded">
                         {!! Form::label('app_id', 'Application ID', ['class' => 'field-label']) !!}
-                        {!! Form::text('app_id', $key['app_id'], ['class' => 'text-field']) !!}
+                        {!! Form::text('app_id', $key->app_id, ['class' => 'text-field']) !!}
                     </div>
 
                     <div class="form-item -padded">
                         {!! Form::label('api_key', 'API Key', ['class' => 'field-label']) !!}
-                        {!! Form::text('api_key', $key['api_key'], ['class' => 'text-field', 'disabled' => true]) !!}
+                        {!! Form::text('api_key', $key->api_key, ['class' => 'text-field', 'disabled' => true]) !!}
                     </div>
 
                     <div class="form-item -padded">
                         {!! Form::label('scope', 'Scope', ['class' => 'field-label']) !!}
                         @foreach($scopes as $scope => $description)
                             <label class="option -checkbox">
-                                {!! Form::checkbox('scope['.$scope.']', $scope, in_array($scope, $key['scope'])) !!}
+                                {!! Form::checkbox('scope['.$scope.']', $scope, in_array($scope, $key->scope)) !!}
                                 <span class="option__indicator"></span>
                                 <span><strong>{{ $scope }}</strong> – {{ $description }}</span>
                             </label>

--- a/resources/views/keys/show.blade.php
+++ b/resources/views/keys/show.blade.php
@@ -7,20 +7,20 @@
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block">
-                <h1>{{ $key['app_id'] }}</h1>
+                <h1>{{ $key->app_id }}</h1>
             </div>
 
             <div class="container__block">
                 <h4>Credentials:</h4>
                 <!-- Strange indentation due to `<pre>` tag respecting all whitespace. -->
-          <pre>  X-DS-Application-Id: {{ $key['app_id'] }}
-  X-DS-REST-API-Key: {{ $key['api_key'] }}</pre>
+          <pre>  X-DS-Application-Id: {{ $key->app_id }}
+  X-DS-REST-API-Key: {{ $key->api_key }}</pre>
             </div>
 
             <div class="container__block">
                 <h4>Scopes</h4>
                 <ul class="list -compacted">
-                    @foreach($key['scope'] as $scope)
+                    @foreach($key->scope as $scope)
                         <li>{{ $scope }}</li>
                     @endforeach
                 </ul>
@@ -29,9 +29,9 @@
             </div>
             <div class="container__block">
                 <ul class="form-actions -inline">
-                    <li><a class="button -secondary" href="{{ route('keys.edit', [ $key['api_key']]) }}">Edit Key</a></li>
+                    <li><a class="button -secondary" href="{{ route('keys.edit', [ $key->api_key]) }}">Edit Key</a></li>
                     <li>
-                        <form action="{{ route('keys.destroy', $key['api_key']) }}" method="POST">
+                        <form action="{{ route('keys.destroy', $key->api_key) }}" method="POST">
                             <input type="hidden" name="_method" value="DELETE">
                             <input type="hidden" name="_token" value="{{ csrf_token() }}">
                             <button class="button -secondary -danger">Delete Key</button>


### PR DESCRIPTION
#### Changes
I think this pretty much wraps up the "tidying" PRs for Aurora.

This updates all controllers to use [route model binding](https://laravel.com/docs/5.1/routing#route-model-binding) to inject relevant models into the controllers (rather than having to re-write the same fetch logic in each method). It also adds a `NorthstarKey` class to wrap API key responses, and a spiffy new 404 page.

---
For review: @angaither 