### PR TITLE
Add RestAPIClient to clean up API classes.

### DIFF
--- a/app/APIResponseCollection.php
+++ b/app/APIResponseCollection.php
@@ -14,20 +14,28 @@ class APIResponseCollection extends Collection
      */
     protected $paginator;
 
-    public function __construct($response)
+    /**
+     * APIResponseCollection constructor.
+     * @param array $response - Array of raw API responses
+     * @param string $class - Class to create for contents
+     */
+    public function __construct($response, $class)
     {
         $items = [];
         foreach ($response['data'] as $item) {
-            array_push($items, new NorthstarUser($item));
+            array_push($items, new $class($item));
         }
 
-        $this->paginator = new \Illuminate\Pagination\LengthAwarePaginator(
-            $response['data'],
-            $response['meta']['pagination']['total'],
-            $response['meta']['pagination']['per_page'],
-            $response['meta']['pagination']['current_page'],
-            ['path' => request()->path()]
-        );
+        // If the response is paginated, create a Paginator.
+        if (isset($response['meta']['pagination'])) {
+            $this->paginator = new \Illuminate\Pagination\LengthAwarePaginator(
+                $response['data'],
+                $response['meta']['pagination']['total'],
+                $response['meta']['pagination']['per_page'],
+                $response['meta']['pagination']['current_page'],
+                ['path' => request()->path()]
+            );
+        }
 
         parent::__construct($items);
     }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace Aurora\Exceptions;
 
 use Exception;
+use Illuminate\Contracts\Validation\ValidationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -18,6 +19,7 @@ class Handler extends ExceptionHandler
     protected $dontReport = [
         HttpException::class,
         ModelNotFoundException::class,
+        ValidationException::class,
     ];
 
     /**
@@ -30,7 +32,7 @@ class Handler extends ExceptionHandler
      */
     public function report(Exception $e)
     {
-        return parent::report($e);
+        parent::report($e);
     }
 
     /**
@@ -42,6 +44,12 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
+        if ($e instanceof ValidationException) {
+            return redirect()->back()
+                ->withInput($request->input())
+                ->withErrors($e->errors());
+        }
+
         if ($e instanceof ModelNotFoundException) {
             $e = new NotFoundHttpException($e->getMessage(), $e);
         }

--- a/app/Services/Northstar.php
+++ b/app/Services/Northstar.php
@@ -5,30 +5,15 @@ namespace Aurora\Services;
 use Aurora\APIResponseCollection;
 use Aurora\NorthstarKey;
 use Aurora\NorthstarUser;
-use GuzzleHttp\Client;
 
-class Northstar
+class Northstar extends RestAPIClient
 {
-    protected $client;
-
     public function __construct()
     {
-        $base_url = config('services.northstar.url');
-        $version = config('services.northstar.version');
+        $base_url = config('services.northstar.url').'/'.config('services.northstar.version').'/';
+        $api_key = config('services.northstar.api_key');
 
-        $client = new Client([
-            'base_url' => [$base_url.'/{version}/', ['version' => $version]],
-            'defaults' => [
-                'headers' => [
-                    'X-DS-Application-Id' => config('services.northstar.app_id'),
-                    'X-DS-REST-API-Key' => config('services.northstar.api_key'),
-                    'Content-Type' => 'application/json',
-                    'Accept' => 'application/json',
-                ],
-            ],
-        ]);
-
-        $this->client = $client;
+        parent::__construct($base_url, ['X-DS-REST-API-Key' => $api_key]);
     }
 
     /**
@@ -38,26 +23,23 @@ class Northstar
      */
     public function login($input)
     {
-        $response = $this->client->post('login', [
-            'body' => json_encode($input),
-        ]);
+        $response = $this->post('login', $input);
 
-        return $response->json()['data'];
+        return $response['data'];
     }
 
     /**
-     * Send a GET request to return all users with given query
-     * from northstar database
+     * Send a GET request to return all users matching a given
+     * query from Northstar.
      *
+     * @param array $inputs - Filter, search, or pagination queries
      * @return APIResponseCollection
      */
-    public function getAllUsers($inputs)
+    public function getAllUsers($inputs = [])
     {
-        $response = $this->client->get('users', [
-            'query' => $inputs,
-        ]);
+        $response = $this->get('users', $inputs);
 
-        return new APIResponseCollection($response->json());
+        return new APIResponseCollection($response, NorthstarUser::class);
     }
 
     /**
@@ -69,120 +51,108 @@ class Northstar
      */
     public function getUser($type, $id)
     {
-        $response = $this->client->get('users'.'/'.$type.'/'.$id);
-        $data = $response->json()['data'];
+        $response = $this->get('users/'.$type.'/'.$id);
 
-        return new NorthstarUser($data);
+        return new NorthstarUser($response['data']);
     }
 
     /**
-     * Send a PUT request to update a user
+     * Send a PUT request to update a user in Northstar.
      *
-     * @param mixed ID, mixed input
+     * @param string $id - Northstar User ID
+     * @param array $input - Fields to update in profile
+     * @return mixed
      */
     public function updateUser($id, $input)
     {
-        $response = $this->client->put('users'.'/_id/'.$id, [
-            'body' => json_encode($input),
-        ]);
+        $response = $this->put('users/_id/'.$id, $input);
+
+        return new NorthstarUser($response['data']);
+    }
+
+    /**
+     * Send a DELETE request to delete a user from Northstar.
+     *
+     * @param $id - Northstar user ID
+     * @return bool - Whether user was successfully deleted
+     */
+    public function deleteUser($id)
+    {
+        $success = $this->delete('users/_id/'.$id);
+
+        return $success;
     }
 
     /**
      * Send a GET request to return all northstar keys
      *
-     * @return JSON keys
+     * @return array - keys
      */
     public function getAllApiKeys()
     {
-        $response = $this->client->get('keys');
+        $response = $this->get('keys');
 
-        return $response->json()['data'];
-    }
-
-    public function getApiKey($api_key)
-    {
-        $response = $this->client->get('keys/'.$api_key);
-        $key = new NorthstarKey($response->json()['data']);
-
-        return $key;
-    }
-
-    public function deleteApiKey($api_key)
-    {
-        $response = $this->client->delete('keys/'.$api_key);
-        $data = $response->json();
-
-        return isset($data['success']) ? true : false;
+        return new APIResponseCollection($response, NorthstarKey::class);
     }
 
     /**
      * Send a POST request to generate new keys to northstar
      *
-     * @param string input
-     * @return JSON file
+     * @param string $api_key - API key
+     * @return NorthstarKey
+     */
+    public function getApiKey($api_key)
+    {
+        $response = $this->get('keys/'.$api_key);
+
+        return new NorthstarKey($response['data']);
+    }
+
+    /**
+     * Send a POST request to create a new API key.
+     *
+     * @param array $input - key values
+     * @return NorthstarKey
      */
     public function createNewApiKey($input)
     {
-        $response = $this->client->post('keys', [
-            'body' => json_encode($input),
-        ]);
-        $key = new NorthstarKey($response->json()['data']);
+        $response = $this->post('keys', $input);
 
-        return $key;
+        return new NorthstarKey($response['data']);
     }
 
     /**
      * Send a POST request to generate new keys to northstar
      *
-     * @param string input
-     * @return JSON file
+     * @param string $api_key - API key
+     * @param array $input - key values
+     * @return NorthstarKey
      */
     public function updateApiKey($api_key, $input)
     {
-        $response = $this->client->put('keys/'.$api_key, [
-            'body' => json_encode($input),
-        ]);
+        $response = $this->put('keys/'.$api_key, $input);
 
-        $key = new NorthstarKey($response->json()['data']);
-
-        return $key;
+        return new NorthstarKey($response['data']);
     }
 
     /**
-     * Send a GET request to return all users matching $type
+     * Send a DELETE request to delete an API key from Northstar.
      *
-     * @todo need to make a parameter for Northstar API's retreive user query to sort by most recent user
-     * @param mixed ID, email, id, phone
-     * @return user objects
+     * @param string $api_key - API key
+     * @return bool - Whether user was successfully deleted
      */
-    public function getUsers($type, $id)
+    public function deleteApiKey($api_key)
     {
-        $response = $this->client->get('users'.'/'.$type.'/'.$id);
-        $northstar_users = $response->json()['data'];
-        // sort users by "updated_at" attribute
-        uasort($northstar_users, function ($a, $b) {
-            if ($a['updated_at'] == $b['updated_at']) {
-                return 0;
-            }
-
-            return ($a['updated_at'] > $b['updated_at']) ? -1 : 1;
-        });
-
-        return $northstar_users;
+        return $this->delete('keys/'.$api_key);
     }
 
     /**
-     * Send a DELETE request to delete an user from northstar database
+     * Get the available scopes for API keys & their descriptions.
      *
-     * @param mixed ID
+     * @return array - key/value array of scopes & descriptions
      */
-    public function deleteUser($id)
-    {
-        $response = $this->client->delete('users/'.$id);
-    }
-
     public function scopes()
     {
-        return $this->client->get('scopes')->json();
+        return $this->get('scopes');
     }
 }

--- a/app/Services/RestAPIClient.php
+++ b/app/Services/RestAPIClient.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Message\Response;
 use Illuminate\Contracts\Validation\ValidationException;
 use Illuminate\Support\MessageBag;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class RestAPIClient
 {
@@ -99,7 +100,7 @@ class RestAPIClient
      * @param $method
      * @param $path
      * @param array $options
-     * @return Response|null
+     * @return Response|void
      */
     public function raw($method, $path, $options = [])
     {
@@ -108,7 +109,7 @@ class RestAPIClient
         } catch (\GuzzleHttp\Exception\ClientException $e) {
             // If it's a validation error, loop through the error response and present as
             // a standard Laravel validation error, so the user can fix their mistakes!
-            if($e->getCode() === 422) {
+            if ($e->getCode() === 422) {
                 $fields = json_decode($e->getResponse()->getBody()->getContents())->errors;
                 $messages = new MessageBag;
 
@@ -120,9 +121,9 @@ class RestAPIClient
 
                 throw new ValidationException($messages);
             }
-        }
 
-        return null;
+            throw new HttpException(500, 'Northstar returned an error for that request.');
+        }
     }
 
     /**

--- a/app/Services/RestAPIClient.php
+++ b/app/Services/RestAPIClient.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Aurora\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Message\Response;
+
+class RestAPIClient
+{
+    protected $client;
+
+    /**
+     * RestAPIClient constructor.
+     *
+     * @param $base_url - Base URL for this API, e.g. https://api.dosomething.org/v1/
+     * @param array $additional_headers - Additional headers that should be sent with every request
+     */
+    public function __construct($base_url, $additional_headers = [])
+    {
+        $standard_headers = [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ];
+
+        $client = new Client([
+            'base_url' => $base_url,
+            'defaults' => [
+                'headers' => array_merge($standard_headers, $additional_headers),
+            ],
+        ]);
+
+        $this->client = $client;
+    }
+
+    /**
+     * Send a GET request to the given URL.
+     *
+     * @param string $path - URL to make request to (relative to base URL)
+     * @param array $query - Key-value array of query string values
+     * @return array
+     */
+    public function get($path, $query = [])
+    {
+        $response = $this->client->get($path, [
+            'query' => $query,
+        ]);
+
+        return $response->json();
+    }
+
+    /**
+     * Send a POST request to the given URL.
+     *
+     * @param string $path - URL to make request to (relative to base URL)
+     * @param array $body
+     * @return array
+     */
+    public function post($path, $body = [])
+    {
+        $response = $this->client->post($path, [
+            'body' => json_encode($body),
+        ]);
+
+        return $response->json();
+    }
+
+    /**
+     * Send a PUT request to the given URL.
+     *
+     * @param string $path - URL to make request to (relative to base URL)
+     * @param array $body
+     * @return array
+     */
+    public function put($path, $body = [])
+    {
+        $response = $this->client->post($path, [
+            'body' => json_encode($body),
+        ]);
+
+        return $response->json();
+    }
+
+    /**
+     * Send a DELETE request to the given URL.
+     *
+     * @param string $path - URL to make request to (relative to base URL)
+     * @return bool
+     */
+    public function delete($path)
+    {
+        $response = $this->client->delete($path);
+
+        return $this->responseSuccessful($response);
+    }
+
+    /**
+     * Determine if the response was successful or not.
+     *
+     * @param $response
+     * @return bool
+     */
+    public function responseSuccessful(Response $response)
+    {
+        return isset($response->json()['success']);
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -17,7 +17,6 @@ return [
     'northstar' => [
         'url'     => env('NORTHSTAR_URL'),
         'version' => 'v1',
-        'app_id'  => env('NORTHSTAR_APP_ID'),
         'api_key' => env('NORTHSTAR_API_KEY'),
     ],
 

--- a/public/assets/custom-neue.css
+++ b/public/assets/custom-neue.css
@@ -32,6 +32,17 @@ pre {
 }
 
 /**
+ * Validation
+ */
+.validation-error {
+  margin: 12px 0;
+}
+
+.validation-error, .validation-error h4 {
+  color: #ff4747;
+}
+
+/**
  * Table
  */
 .table {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -14,13 +14,7 @@
                 </p>
             <p>Drop a message in the <code>#api</code> Slack room if you can't log in!</p>
 
-            @if (count($errors) > 0)
-                <ul class="list validation-errors">
-                    @foreach ($errors->all() as $error)
-                        <li>{{ $error }}</li>
-                    @endforeach
-                </ul>
-            @endif
+            @include('layout.errors')
 
             {!! Form::open(['url' => '/auth/login', 'method' => 'POST', 'class' => 'form-signin']) !!}
             <div class="form-item -padded">

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,0 +1,25 @@
+@extends('layout.master')
+
+@section('main_content')
+
+    @include('layout.header', ["header" => "Boom!", "subtitle" => "We couldn't finish this request."])
+
+    <div class="container -padded">
+        <div class="wrapper">
+            <div class="container__block -narrow">
+                <h1>Drat, something went wrong.</h1>
+                <p>Something went wrong with this request, and Aurora wasn't able to fix it. Please
+                    <a href="https://github.com/DoSomething/aurora/issues/new">report an issue</a> with the details listed below
+                    and we'll try to figure out what might have went wrong.</p>
+            </div>
+
+            <div class="container__block -narrow">
+                <div class="footnote">
+                    <h4>Technical Details</h4>
+                    [{{ $exception->getStatusCode() }}] {{ $exception->getMessage() }}<br/>
+                    {{ request()->url() }}
+                </div>
+            </div>
+        </div>
+    </div>
+@stop

--- a/resources/views/keys/create.blade.php
+++ b/resources/views/keys/create.blade.php
@@ -8,6 +8,9 @@
         <div class="wrapper">
             <div class="container__block -narrow">
                 <h1>Create API Key</h1>
+
+                @include('layout.errors')
+
                 {!! Form::open(['route' => 'keys.store', 'method' => 'post']) !!}
                     <div class="form-item -padded">
                         {!! Form::label('app_id', 'Application ID', ['class' => 'field-label']) !!}

--- a/resources/views/keys/edit.blade.php
+++ b/resources/views/keys/edit.blade.php
@@ -8,6 +8,9 @@
         <div class="wrapper">
             <div class="container__block -narrow">
                 <h1>{{ $key->app_id }}</h1>
+
+                @include('layout.errors')
+
                 {!! Form::open(['route' => ['keys.update', $key->api_key], 'method' => 'PUT']) !!}
                     <div class="form-item -padded">
                         {!! Form::label('app_id', 'Application ID', ['class' => 'field-label']) !!}

--- a/resources/views/keys/index.blade.php
+++ b/resources/views/keys/index.blade.php
@@ -13,13 +13,13 @@
                   <li>
                       <article class="figure -left">
                           <div class="figure__media">
-                              <a href="{{ route('keys.show', [$key['api_key']]) }}">
-                                  <img alt="key" src="/assets/key{{ in_array('admin', $key['scope']) ? '-admin' : '' }}.svg" />
+                              <a href="{{ route('keys.show', [$key->api_key]) }}">
+                                  <img alt="key" src="/assets/key{{ in_array('admin', $key->scope) ? '-admin' : '' }}.svg" />
                               </a>
                           </div>
                           <div class="figure__body">
-                              <h4><a href="{{ route('keys.show', [$key['api_key']]) }}">{{ $key['app_id'] }}</a></h4>
-                              <span class="footnote">{{ implode(', ', $key['scope']) }}</span>
+                              <h4><a href="{{ route('keys.show', [$key->api_key]) }}">{{ $key->app_id }}</a></h4>
+                              <span class="footnote">{{ implode(', ', $key->scope) }}</span>
                           </div>
                       </article>
                   </li>

--- a/resources/views/keys/show.blade.php
+++ b/resources/views/keys/show.blade.php
@@ -12,9 +12,8 @@
 
             <div class="container__block">
                 <h4>Credentials:</h4>
-                <!-- Strange indentation due to `<pre>` tag respecting all whitespace. -->
-          <pre>  X-DS-Application-Id: {{ $key->app_id }}
-  X-DS-REST-API-Key: {{ $key->api_key }}</pre>
+                <pre>X-DS-REST-API-Key: {{ $key->api_key }}</pre>
+                <p class="footnote">Send this header with any requests to use this API key.</p>
             </div>
 
             <div class="container__block">

--- a/resources/views/layout/errors.blade.php
+++ b/resources/views/layout/errors.blade.php
@@ -1,0 +1,10 @@
+@if ($errors->count())
+    <div class="validation-error fade-in-up">
+        <h4>Hmm, there were some issues with that submission:</h4>
+        <ul class="list -compacted">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -8,6 +8,9 @@
   <div class="wrapper">
       <div class="container__block -narrow">
           <h1>Edit Profile</h1>
+
+          @include('layout.errors')
+
           {!! Form::model($user, [ 'method' => 'PATCH', 'route' => ['users.update', $user->id]]) !!}
           <div class="form-item -padded">
               {!! Form::label('_id', 'Northstar ID', ['class' => 'field-label']) !!}


### PR DESCRIPTION
### Changes

##### REST API client cleanup
Adds a small helper class to clean up calls to RESTful APIs so we don’t have to have so much boilerplate. Also updates documentation!

##### Properly handles validation errors
Aurora would previously explode :bomb: if it received a `422` response from Northstar. We now explicitly catch any Guzzle client exceptions and, if it's a validation error, format and display them.

![screen shot 2016-02-02 at 1 28 07 pm](https://cloud.githubusercontent.com/assets/583202/12759764/03d3db72-c9b1-11e5-9c89-344ec6c1ab3d.png)

##### Add a nice 500 page
This also adds a nice 500 page (which will be used for any `HttpExceptions`, such as any uncaught exception returned from the Northstar API). This does _not_ replace fatal errors (like calling an nonexistent method), which are still sent to the Symphony "whoops" reporter.

---
For review: @angaither @weerd 