### PR TITLE
Update for northstar auth

### DIFF
--- a/app/APIResponseModel.php
+++ b/app/APIResponseModel.php
@@ -14,18 +14,18 @@ class APIResponseModel
     protected $attributes = [];
 
     /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [];
-
-    /**
      * The attributes that should be mutated to dates.
      *
      * @var array
      */
     protected $dates = [];
+
+    /**
+     * Indicates if the includes timestamps.
+     *
+     * @var bool
+     */
+    protected $timestamps = true;
 
     /**
      * The name of the "created at" column.
@@ -92,13 +92,6 @@ class APIResponseModel
             return $this->mutateAttribute($key, $value);
         }
 
-        // If the attribute exists within the cast array, we will convert it to
-        // an appropriate native PHP type dependant upon the associated value
-        // given with the key in the pair. Dayle made this comment line up.
-        if ($this->hasCast($key)) {
-            $value = $this->castAttribute($key, $value);
-        }
-
         // If the attribute is listed as a date, we will convert it to a DateTime
         // instance on retrieval, which makes it quite convenient to work with
         // date fields without having to create a mutator for each property.
@@ -145,81 +138,6 @@ class APIResponseModel
     protected function mutateAttribute($key, $value)
     {
         return $this->{'get'.Str::studly($key).'Attribute'}($value);
-    }
-
-    /**
-     * Determine whether an attribute should be cast to a native type.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    protected function hasCast($key)
-    {
-        return array_key_exists($key, $this->casts);
-    }
-
-    /**
-     * Determine whether a value is Date / DateTime castable for inbound manipulation.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    protected function isDateCastable($key)
-    {
-        return $this->hasCast($key) &&
-        in_array($this->getCastType($key), ['date', 'datetime'], true);
-    }
-
-    /**
-     * Get the type of cast for a model attribute.
-     *
-     * @param  string  $key
-     * @return string
-     */
-    protected function getCastType($key)
-    {
-        return trim(strtolower($this->casts[$key]));
-    }
-
-    /**
-     * Cast an attribute to a native PHP type.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return mixed
-     */
-    protected function castAttribute($key, $value)
-    {
-        if (is_null($value)) {
-            return $value;
-        }
-
-        switch ($this->getCastType($key)) {
-            case 'int':
-            case 'integer':
-                return (int) $value;
-            case 'real':
-            case 'float':
-            case 'double':
-                return (float) $value;
-            case 'string':
-                return (string) $value;
-            case 'bool':
-            case 'boolean':
-                return (bool) $value;
-            // case 'object':
-            //     return $this->fromJson($value, true);
-            // case 'array':
-            // case 'json':
-            //     return $this->fromJson($value);
-            // case 'collection':
-            //    return new BaseCollection($this->fromJson($value));
-            case 'date':
-            case 'datetime':
-                return $this->asDateTime($value);
-            default:
-                return $value;
-        }
     }
 
     /**

--- a/app/APIResponseModel.php
+++ b/app/APIResponseModel.php
@@ -18,14 +18,7 @@ class APIResponseModel
      *
      * @var array
      */
-    protected $dates = [];
-
-    /**
-     * Indicates if the includes timestamps.
-     *
-     * @var bool
-     */
-    protected $timestamps = true;
+    protected $dates = [self::CREATED_AT, self::UPDATED_AT];
 
     /**
      * The name of the "created at" column.
@@ -95,7 +88,7 @@ class APIResponseModel
         // If the attribute is listed as a date, we will convert it to a DateTime
         // instance on retrieval, which makes it quite convenient to work with
         // date fields without having to create a mutator for each property.
-        elseif (in_array($key, $this->getDates())) {
+        elseif (in_array($key, $this->dates)) {
             if (! is_null($value)) {
                 return $this->asDateTime($value);
             }
@@ -138,18 +131,6 @@ class APIResponseModel
     protected function mutateAttribute($key, $value)
     {
         return $this->{'get'.Str::studly($key).'Attribute'}($value);
-    }
-
-    /**
-     * Get the attributes that should be converted to dates.
-     *
-     * @return array
-     */
-    public function getDates()
-    {
-        $defaults = [static::CREATED_AT, static::UPDATED_AT];
-
-        return $this->timestamps ? array_merge($this->dates, $defaults) : $this->dates;
     }
 
     /**

--- a/app/Auth/NorthstarUserProvider.php
+++ b/app/Auth/NorthstarUserProvider.php
@@ -2,7 +2,6 @@
 
 namespace Aurora\Auth;
 
-use GuzzleHttp\Exception\ClientException;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Auth\EloquentUserProvider;
@@ -17,13 +16,16 @@ class NorthstarUserProvider extends EloquentUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        // Get the Northstar user
-        $northstar = new \Aurora\Services\Northstar;
-        $response = $northstar->getUser('email', $credentials['email']);
+        $northstar = app('\Aurora\Services\Northstar');
+        $user = $northstar->getUser('email', $credentials['email']);
+
+        if (! $user) {
+            return null;
+        }
 
         // If a matching user is found, find or create local Aurora user.
         return $this->createModel()->firstOrCreate([
-            'northstar_id' => $response->id,
+            'northstar_id' => $user->id,
         ]);
     }
 
@@ -36,8 +38,9 @@ class NorthstarUserProvider extends EloquentUserProvider implements UserProvider
      */
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
-        $northstar = new \Aurora\Services\Northstar;
+        $northstar = app('\Aurora\Services\Northstar');
+        $user = $northstar->verify($credentials);
 
-        return ! is_null($northstar->verify($credentials));
+        return ! is_null($user);
     }
 }

--- a/app/Auth/NorthstarUserProvider.php
+++ b/app/Auth/NorthstarUserProvider.php
@@ -37,14 +37,7 @@ class NorthstarUserProvider extends EloquentUserProvider implements UserProvider
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
         $northstar = new \Aurora\Services\Northstar;
-        try {
-            $northstar->login($credentials);
 
-            return true;
-        } catch (ClientException $e) {
-            // If an exception is returned, we couldn't log in...
-        }
-
-        return false;
+        return ! is_null($northstar->verify($credentials));
     }
 }

--- a/app/Http/helpers.php
+++ b/app/Http/helpers.php
@@ -36,28 +36,6 @@ function message_state_class($status)
 }
 
 /**
- * Modify phone number given into the the origin country format
- * https://github.com/giggsey/libphonenumber-for-php
- *
- * @param string number
- * @param string country name(set to US by default)
- * @return string of formatted phone number
- */
-function sanitize_phone_number($number, $countryName = 'US')
-{
-    $phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
-    try {
-        $formattedNumber = $phoneUtil->parse($number, $countryName);
-
-        return $phoneUtil->format($formattedNumber, \libphonenumber\PhoneNumberFormat::INTERNATIONAL);
-    } catch (\libphonenumber\NumberParseException $e) {
-        Log::error($e);
-
-        return $number;
-    }
-}
-
-/**
  * When duplicate users occur, this function is called to add a class to html
  * markup
  *

--- a/app/NorthstarKey.php
+++ b/app/NorthstarKey.php
@@ -4,17 +4,5 @@ namespace Aurora;
 
 class NorthstarKey extends APIResponseModel
 {
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [];
-
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = ['created_at', 'updated_at'];
+    // @see \Aurora\APIResponseModel
 }

--- a/app/NorthstarUser.php
+++ b/app/NorthstarUser.php
@@ -27,6 +27,10 @@ class NorthstarUser extends APIResponseModel
      */
     public function displayName()
     {
+        if (! empty($this->first_name) && ! empty($this->last_name)) {
+            return $this->first_name.' '.$this->last_name;
+        }
+
         if (! empty($this->first_name) && ! empty($this->last_initial)) {
             return $this->first_name.' '.$this->last_initial.'.';
         }
@@ -58,6 +62,7 @@ class NorthstarUser extends APIResponseModel
         return $fallback;
     }
 
+    /**
      * Get all user's campaigns
      *
      * @return array user's campaigns

--- a/app/NorthstarUser.php
+++ b/app/NorthstarUser.php
@@ -2,6 +2,10 @@
 
 namespace Aurora;
 
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
+use Log;
+
 class NorthstarUser extends APIResponseModel
 {
     /**
@@ -31,6 +35,29 @@ class NorthstarUser extends APIResponseModel
     }
 
     /**
+     * Get the user's formatted mobile number.
+     *
+     * @param string $fallback - Text to display if no mobile is set
+     * @return mixed|string
+     */
+    public function prettyMobile($fallback = '')
+    {
+        if(isset($this->mobile)) {
+            $phoneUtil = PhoneNumberUtil::getInstance();
+            try {
+                $formattedNumber = $phoneUtil->parse($this->mobile, 'US');
+
+                return $phoneUtil->format($formattedNumber, PhoneNumberFormat::INTERNATIONAL);
+            } catch (\libphonenumber\NumberParseException $e) {
+                Log::error($e);
+
+                return $this->number;
+            }
+        }
+
+        return $fallback;
+    }
+
      * Get all user's campaigns
      *
      * @return array user's campaigns

--- a/app/NorthstarUser.php
+++ b/app/NorthstarUser.php
@@ -10,14 +10,6 @@ class NorthstarUser extends APIResponseModel
      */
     protected $drupal;
 
-
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = ['created_at', 'updated_at'];
-
     public function __construct($attributes)
     {
         $this->drupal = app('Aurora\Services\Drupal');

--- a/app/NorthstarUser.php
+++ b/app/NorthstarUser.php
@@ -46,7 +46,7 @@ class NorthstarUser extends APIResponseModel
      */
     public function prettyMobile($fallback = '')
     {
-        if(isset($this->mobile)) {
+        if (isset($this->mobile)) {
             $phoneUtil = PhoneNumberUtil::getInstance();
             try {
                 $formattedNumber = $phoneUtil->parse($this->mobile, 'US');

--- a/app/NorthstarUser.php
+++ b/app/NorthstarUser.php
@@ -10,12 +10,6 @@ class NorthstarUser extends APIResponseModel
      */
     protected $drupal;
 
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [];
 
     /**
      * The attributes that should be mutated to dates.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Aurora\Providers;
 
+use Aurora\Services\Northstar;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +24,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->app->singleton('\Aurora\Services\Northstar', function () {
+            return new Northstar(config('services.northstar'));
+        });
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Aurora\Providers;
 
-use GuzzleHttp\Exception\ClientException;
 use Illuminate\Routing\Router;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -27,23 +26,23 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(Router $router)
     {
         $router->bind('users', function ($id) {
-            try {
-                $user = app('\Aurora\Services\Northstar')->getUser('_id', $id);
+            $user = app('\Aurora\Services\Northstar')->getUser('_id', $id);
 
-                return $user;
-            } catch (ClientException $e) {
+            if (! $user) {
                 throw new NotFoundHttpException;
             }
+
+            return $user;
         });
 
         $router->bind('keys', function ($id) {
-            try {
-                $key = app('\Aurora\Services\Northstar')->getApiKey($id);
+            $key = app('\Aurora\Services\Northstar')->getApiKey($id);
 
-                return $key;
-            } catch (ClientException $e) {
+            if (! $key) {
                 throw new NotFoundHttpException;
             }
+
+            return $key;
         });
 
         $router->model('aurora-users', '\Aurora\Models\AuroraUser');

--- a/app/Services/Northstar.php
+++ b/app/Services/Northstar.php
@@ -5,6 +5,8 @@ namespace Aurora\Services;
 use Aurora\APIResponseCollection;
 use Aurora\NorthstarKey;
 use Aurora\NorthstarUser;
+use GuzzleHttp\Exception\ClientException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class Northstar extends RestAPIClient
 {
@@ -17,15 +19,32 @@ class Northstar extends RestAPIClient
     }
 
     /**
-     * Send a POST request to login the user.
+     * Send a POST request to verify the user's credentials.
      *
-     * @param array - input
+     * @param array $credentials
+     *   ex: ['email' => '...', 'password' => '...']
+     *       ['mobile' => '...', 'password' => '...']
+     * @return NorthstarUser|null
      */
-    public function login($input)
+    public function verify($credentials)
     {
-        $response = $this->post('login', $input);
+        try {
+            $response = $this->raw('POST', 'auth/verify', [
+                'body' => json_encode($credentials),
+            ]);
 
-        return $response['data'];
+            return new NorthstarUser($response->json()['data']);
+        } catch (ClientException $e) {
+            $code = $e->getCode();
+            if($code === 401 || $code === 422) {
+                // If 401 Unauthorized or 422 Unprocessable Entity, then
+                // these are invalid credentials.
+                return null;
+            }
+
+            // Otherwise, something unexpected went wrong.
+            throw new HttpException(500, 'Northstar returned an error for that request.');
+        }
     }
 
     /**
@@ -84,7 +103,7 @@ class Northstar extends RestAPIClient
     }
 
     /**
-     * Send a GET request to return all northstar keys
+     * Send a GET request to return all Northstar keys.
      *
      * @return array - keys
      */
@@ -96,19 +115,6 @@ class Northstar extends RestAPIClient
     }
 
     /**
-     * Send a POST request to generate new keys to northstar
-     *
-     * @param string $api_key - API key
-     * @return NorthstarKey
-     */
-    public function getApiKey($api_key)
-    {
-        $response = $this->get('keys/'.$api_key);
-
-        return new NorthstarKey($response['data']);
-    }
-
-    /**
      * Send a POST request to create a new API key.
      *
      * @param array $input - key values
@@ -117,6 +123,19 @@ class Northstar extends RestAPIClient
     public function createNewApiKey($input)
     {
         $response = $this->post('keys', $input);
+
+        return new NorthstarKey($response['data']);
+    }
+
+    /**
+     * Send a GET request to get the specified key.
+     *
+     * @param string $api_key - API key
+     * @return NorthstarKey
+     */
+    public function getApiKey($api_key)
+    {
+        $response = $this->get('keys/'.$api_key);
 
         return new NorthstarKey($response['data']);
     }

--- a/app/Services/Northstar.php
+++ b/app/Services/Northstar.php
@@ -40,7 +40,7 @@ class Northstar extends RestAPIClient
             return new NorthstarUser($response->json()['data']);
         } catch (ClientException $e) {
             $code = $e->getCode();
-            if($code === 401 || $code === 422) {
+            if ($code === 401 || $code === 422) {
                 // If 401 Unauthorized or 422 Unprocessable Entity, then
                 // these are invalid credentials.
                 return null;
@@ -76,7 +76,7 @@ class Northstar extends RestAPIClient
     {
         $response = $this->get('users/'.$type.'/'.$id);
 
-        if(is_null($response)) {
+        if (is_null($response)) {
             return null;
         }
 

--- a/app/Services/Northstar.php
+++ b/app/Services/Northstar.php
@@ -76,6 +76,10 @@ class Northstar extends RestAPIClient
     {
         $response = $this->get('users/'.$type.'/'.$id);
 
+        if(is_null($response)) {
+            return null;
+        }
+
         return new NorthstarUser($response['data']);
     }
 

--- a/app/Services/Northstar.php
+++ b/app/Services/Northstar.php
@@ -10,10 +10,14 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class Northstar extends RestAPIClient
 {
-    public function __construct()
+    /**
+     * Northstar constructor.
+     * @param array $config
+     */
+    public function __construct($config = [])
     {
-        $base_url = config('services.northstar.url').'/'.config('services.northstar.version').'/';
-        $api_key = config('services.northstar.api_key');
+        $base_url = $config['url'].'/'.$config['version'].'/';
+        $api_key = $config['api_key'];
 
         parent::__construct($base_url, ['X-DS-REST-API-Key' => $api_key]);
     }

--- a/app/Services/RestAPIClient.php
+++ b/app/Services/RestAPIClient.php
@@ -44,7 +44,7 @@ class RestAPIClient
      */
     public function get($path, $query = [])
     {
-        $response = $this->raw('GET', $path, [
+        $response = $this->send('GET', $path, [
             'query' => $query,
         ]);
 
@@ -60,7 +60,7 @@ class RestAPIClient
      */
     public function post($path, $body = [])
     {
-        $response = $this->raw('POST', $path, [
+        $response = $this->send('POST', $path, [
             'body' => json_encode($body),
         ]);
 
@@ -76,7 +76,7 @@ class RestAPIClient
      */
     public function put($path, $body = [])
     {
-        $response = $this->raw('PUT', $path, [
+        $response = $this->send('PUT', $path, [
             'body' => json_encode($body),
         ]);
 
@@ -91,7 +91,7 @@ class RestAPIClient
      */
     public function delete($path)
     {
-        $response = $this->raw('DELETE', $path);
+        $response = $this->send('DELETE', $path);
 
         return $this->responseSuccessful($response);
     }
@@ -102,11 +102,12 @@ class RestAPIClient
      * @param array $options
      * @return Response|void
      */
-    public function raw($method, $path, $options = [])
+    public function send($method, $path, $options = [])
     {
         try {
             return $this->client->send($this->client->createRequest($method, $path, $options));
         } catch (\GuzzleHttp\Exception\ClientException $e) {
+            dd($e);
             // If it's a validation error, loop through the error response and present as
             // a standard Laravel validation error, so the user can fix their mistakes!
             if ($e->getCode() === 422) {
@@ -124,6 +125,17 @@ class RestAPIClient
 
             throw new HttpException(500, 'Northstar returned an error for that request.');
         }
+    }
+
+    /**
+     * @param $method
+     * @param $path
+     * @param array $options
+     * @return Response|void
+     */
+    public function raw($method, $path, $options)
+    {
+        return $this->client->send($this->client->createRequest($method, $path, $options));
     }
 
     /**

--- a/app/Services/RestAPIClient.php
+++ b/app/Services/RestAPIClient.php
@@ -7,7 +7,6 @@ use GuzzleHttp\Message\Response;
 use Illuminate\Contracts\Validation\ValidationException;
 use Illuminate\Support\MessageBag;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RestAPIClient
 {
@@ -112,7 +111,7 @@ class RestAPIClient
             return $this->raw($method, $path, $options);
         } catch (\GuzzleHttp\Exception\ClientException $e) {
             // If the resource doesn't exist, return null.
-            if($e->getCode() === 404) {
+            if ($e->getCode() === 404) {
                 return null;
             }
 

--- a/resources/views/users/partials/index-table.blade.php
+++ b/resources/views/users/partials/index-table.blade.php
@@ -1,8 +1,7 @@
 <table id="user-table" class="table">
 	<thead>
 		<tr class="row table-header">
-			<th class="table-cell">User ID</th>
-			<th class="table-cell">Name</th>
+			<th class="table-cell">User</th>
 			<th class="table-cell">Email</th>
 			<th class="table-cell">Phone</th>
 		</tr>
@@ -10,9 +9,8 @@
 	<tbody>
 		@forelse($users as $user)
 			<tr class="table-row">
-				<td class="table-cell"> <a href="{{ route('users.show', [$user->id]) }}">{{ $user->id }}</a></td>
-				<td class="table-cell"> {{ $user->first_name or '' }} {{ $user->last_initial or '' }}</td>
-				<td class="table-cell"> {{ $user->email or '' }}</td>
+				<td class="table-cell"><a href="{{ route('users.show', [$user->id]) }}">{{ $user->displayName() }}</a></td>
+				<td class="table-cell">{{ $user->email or '' }}</td>
 				<td class="table-cell">{{ $user->prettyMobile() }}</td>
 			</tr>
 		@empty

--- a/resources/views/users/partials/index-table.blade.php
+++ b/resources/views/users/partials/index-table.blade.php
@@ -13,7 +13,7 @@
 				<td class="table-cell"> <a href="{{ route('users.show', [$user->id]) }}">{{ $user->id }}</a></td>
 				<td class="table-cell"> {{ $user->first_name or '' }} {{ $user->last_initial or '' }}</td>
 				<td class="table-cell"> {{ $user->email or '' }}</td>
-				<td class="table-cell"> {{ isset($user->mobile) ? e(sanitize_phone_number($user->mobile)) : '' }}</td>
+				<td class="table-cell">{{ $user->prettyMobile() }}</td>
 			</tr>
 		@empty
 		@endforelse

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -18,11 +18,13 @@
                 <dt>First Name:</dt><dd>{{ $user->first_name or '&mdash;' }}</dd>
                 <dt>Last Name:</dt><dd>{{ $user->last_name or '&mdash;' }}</dd>
                 <dt>Email:</dt><dd>{{ $user->email or '&mdash;' }}</dd>
-                <dt>Mobile:</dt><dd>{{ $user->mobile or '&mdash;' }}</dd>
+                <dt>Mobile:</dt><dd>{{ $user->prettyMobile('&mdash;') }}</dd>
                 <dt>Birthdate:</dt><dd>{{ $user->birthdate or '&mdash;' }}</dd>
 
                 @if (isset($user->addr_street1) || isset($user->addr_street2) || isset($user->addr_city) || isset($user->addr_state) || isset($user->addr_zip) )
                     <dt>Address:</dt><dd>{{ $user->addr_street1 or '' }} {{ $user->addr_street2 or '' }} {{ $user->addr_city or '' }} {{ $user->addr_state or '' }} {{ $user->addr_zip or '' }}</dd>
+                @else
+                    <dt>Address:</dt><dd>&mdash;</dd>
                 @endif
 
                 <dt>Country:</dt><dd>{{ $user->country or '&mdash;' }}</dd>


### PR DESCRIPTION
#### Changes
Includes updates for Northstar authentication changes in DoSomething/northstar#268.

Other notable changes:

* Removes casting from the API model class for integers, floats, strings, and booleans. I had copied this over when I extracted this stuff from Eloquent's model class, but it doesn't really make any sense to have since JSON supports all the "cartable" data types natively. Also cleans up date casting.
* Move "formatted" number helper into User model (rather than as a global helper method).
* Return `null` when an endpoint 404s. This saves us from having more try/catch blocks than we need to, and seems like a reasonable way to handle this kind of thing.
* Make `Northstar` API class a singleton and inject config values through the service container (which will help us eventually break this class out into a standalone Northstar API package!)
* Adds some missing docblocks and stuff.

---
For review: @angaither / @weerd 