### PR TITLE
Adding backup support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,11 @@
         "laravelcollective/html": "5.1.*",
         "guzzlehttp/guzzle": "~6.2.1",
         "doctrine/dbal": "^2.5",
-        "dosomething/northstar": "1.0.0-rc7"
+        "dosomething/northstar": "1.0.0-rc7",
+        "spatie/laravel-backup": "^3.10",
+        "maknz/slack-laravel": "^1.0",
+        "aws/aws-sdk-php-laravel": "^3.1",
+        "league/flysystem-aws-s3-v3": "~1.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,145 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f89ed9f738d41bd0d3ebde612ade7f41",
-    "content-hash": "c80cfdfccd06c3426b278d003c5bed0f",
+    "hash": "54a32763f23fecbd977b59906a1cc281",
+    "content-hash": "52e7d08574f7fdeb4ba5cecdc5513666",
     "packages": [
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.19.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "3cb90413129da42c9d3289d542bee0ae1049892c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3cb90413129da42c9d3289d542bee0ae1049892c",
+                "reference": "3cb90413129da42c9d3289d542bee0ae1049892c",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "~1.3.1",
+                "mtdowling/jmespath.php": "~2.2",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "ext-spl": "*",
+                "nette/neon": "^2.3",
+                "phpunit/phpunit": "~4.0|~5.0",
+                "psr/cache": "^1.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "http://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "http://aws.amazon.com/sdkforphp",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "time": "2016-08-23 20:58:48"
+        },
+        {
+            "name": "aws/aws-sdk-php-laravel",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php-laravel.git",
+                "reference": "3b946892d493b91b4920ec4facc4a0ad7195fb86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php-laravel/zipball/3b946892d493b91b4920ec4facc4a0ad7195fb86",
+                "reference": "3b946892d493b91b4920ec4facc4a0ad7195fb86",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "~3.0",
+                "illuminate/support": "~5.1",
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0|~5.0"
+            },
+            "suggest": {
+                "laravel/framework": "To test the Laravel bindings",
+                "laravel/lumen-framework": "To test the Lumen bindings"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Aws\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "http://aws.amazon.com"
+                }
+            ],
+            "description": "A simple Laravel 5 service provider for including the AWS SDK for PHP.",
+            "homepage": "http://aws.amazon.com/sdkforphp2",
+            "keywords": [
+                "amazon",
+                "aws",
+                "dynamodb",
+                "ec2",
+                "laravel",
+                "laravel 5",
+                "s3",
+                "sdk"
+            ],
+            "time": "2016-01-18 06:57:07"
+        },
         {
             "name": "classpreloader/classpreloader",
             "version": "3.0.0",
@@ -1455,6 +1591,53 @@
             "time": "2016-07-18 12:22:57"
         },
         {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "1.0.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "dc56a8faf3aff0841f9eae04b6af94a50657896c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/dc56a8faf3aff0841f9eae04b6af94a50657896c",
+                "reference": "dc56a8faf3aff0841f9eae04b6af94a50657896c",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.0.0",
+                "league/flysystem": "~1.0",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "~1.0.1",
+                "phpspec/phpspec": "^2.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3v3\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Flysystem adapter for the AWS S3 SDK v3.x",
+            "time": "2016-06-21 21:34:35"
+        },
+        {
             "name": "league/oauth2-client",
             "version": "1.4.1",
             "source": {
@@ -1516,6 +1699,96 @@
                 "single sign on"
             ],
             "time": "2016-04-29 15:11:06"
+        },
+        {
+            "name": "maknz/slack",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maknz/slack.git",
+                "reference": "7f21fefc70c76b304adc1b3a780c8740dfcfb595"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maknz/slack/zipball/7f21fefc70c76b304adc1b3a780c8740dfcfb595",
+                "reference": "7f21fefc70c76b304adc1b3a780c8740dfcfb595",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "0.9.*",
+                "phpunit/phpunit": "4.2.*"
+            },
+            "suggest": {
+                "illuminate/support": "Required for Laravel support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Maknz\\Slack\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "maknz",
+                    "email": "github@mak.geek.nz"
+                }
+            ],
+            "description": "A simple PHP package for sending messages to Slack, with a focus on ease of use and elegant syntax. Includes Laravel support out of the box.",
+            "keywords": [
+                "laravel",
+                "slack"
+            ],
+            "time": "2015-06-03 03:35:16"
+        },
+        {
+            "name": "maknz/slack-laravel",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maknz/slack-laravel.git",
+                "reference": "d62741f731c963c71272159b38f8209ce57ff85b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maknz/slack-laravel/zipball/d62741f731c963c71272159b38f8209ce57ff85b",
+                "reference": "d62741f731c963c71272159b38f8209ce57ff85b",
+                "shasum": ""
+            },
+            "require": {
+                "maknz/slack": "~1.0",
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Maknz\\Slack\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "maknz",
+                    "email": "github@mak.geek.nz"
+                }
+            ],
+            "description": "Laravel 4 and 5 integration for the maknz/slack package, including facades and service providers.",
+            "keywords": [
+                "laravel",
+                "slack"
+            ],
+            "time": "2016-06-25 06:08:23"
         },
         {
             "name": "monolog/monolog",
@@ -1638,6 +1911,61 @@
                 "schedule"
             ],
             "time": "2016-01-26 21:23:30"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "192f93e43c2c97acde7694993ab171b3de284093"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/192f93e43c2c97acde7694993ab171b3de284093",
+                "reference": "192f93e43c2c97acde7694993ab171b3de284093",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                },
+                "files": [
+                    "src/JmesPath.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "time": "2016-01-05 18:25:05"
         },
         {
             "name": "nesbot/carbon",
@@ -1943,6 +2271,119 @@
                 "shell"
             ],
             "time": "2016-03-09 05:03:14"
+        },
+        {
+            "name": "spatie/db-dumper",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/db-dumper.git",
+                "reference": "efdf41891a9dd4bb63fb6253044c9e51f34fff41"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/efdf41891a9dd4bb63fb6253044c9e51f34fff41",
+                "reference": "efdf41891a9dd4bb63fb6253044c9e51f34fff41",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5|^7.0",
+                "symfony/process": "^2.7|^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\DbDumper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Dump databases",
+            "homepage": "https://github.com/spatie/db-dumper",
+            "keywords": [
+                "database",
+                "db-dumper",
+                "dump",
+                "mysqldump",
+                "spatie"
+            ],
+            "time": "2016-06-14 13:23:01"
+        },
+        {
+            "name": "spatie/laravel-backup",
+            "version": "3.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-backup.git",
+                "reference": "1f9f0c55d7643aba7257aef2b2b867f2716ddfaf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/1f9f0c55d7643aba7257aef2b2b867f2716ddfaf",
+                "reference": "1f9f0c55d7643aba7257aef2b2b867f2716ddfaf",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "~5.1.0|~5.2.0|~5.3.0",
+                "illuminate/filesystem": "~5.1.20|~5.2.0|~5.3.0",
+                "illuminate/support": "~5.1.0|~5.2.0|~5.3.0",
+                "league/flysystem": "^1.0.8",
+                "php": "^5.5|^7.0",
+                "spatie/db-dumper": "^1.3",
+                "symfony/finder": "^2.7|^3.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "orchestra/testbench": "^3.2",
+                "phpunit/phpunit": "^4.8"
+            },
+            "suggest": {
+                "irazasyed/telegram-bot-sdk": "Allows notifications to be sent using Telegram Bot",
+                "maknz/slack": "Allows notifications to be sent via Slack"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Backup\\": "src"
+                },
+                "files": [
+                    "src/Helpers/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Laravel 5 package to backup your application",
+            "homepage": "https://github.com/spatie/laravel-backup",
+            "keywords": [
+                "backup",
+                "database",
+                "laravel-backup",
+                "spatie"
+            ],
+            "time": "2016-08-24 12:02:50"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/config/app.php
+++ b/config/app.php
@@ -142,6 +142,9 @@ return [
          */
         DoSomething\Northstar\Laravel\NorthstarServiceProvider::class,
         Collective\Html\HtmlServiceProvider::class,
+        Spatie\Backup\BackupServiceProvider::class,
+        Maknz\Slack\Laravel\ServiceProvider::class,
+        Aws\Laravel\AwsServiceProvider::class,
 
         /*
          * Application Service Providers...
@@ -168,6 +171,7 @@ return [
         'App'       => Illuminate\Support\Facades\App::class,
         'Artisan'   => Illuminate\Support\Facades\Artisan::class,
         'Auth'      => Illuminate\Support\Facades\Auth::class,
+        'AWS' => Aws\Laravel\AwsFacade::class,
         'Blade'     => Illuminate\Support\Facades\Blade::class,
         'Bus'       => Illuminate\Support\Facades\Bus::class,
         'Cache'     => Illuminate\Support\Facades\Cache::class,
@@ -194,6 +198,7 @@ return [
         'Route'     => Illuminate\Support\Facades\Route::class,
         'Schema'    => Illuminate\Support\Facades\Schema::class,
         'Session'   => Illuminate\Support\Facades\Session::class,
+        'Slack'     => Maknz\Slack\Laravel\Facade::class,
         'Storage'   => Illuminate\Support\Facades\Storage::class,
         'URL'       => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,

--- a/config/aws.php
+++ b/config/aws.php
@@ -1,0 +1,25 @@
+<?php
+
+use Aws\Laravel\AwsServiceProvider;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | AWS SDK Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The configuration options set in this file will be passed directly to the
+    | `Aws\Sdk` object, from which all client objects are created. The minimum
+    | required options are declared here, but the full set of possible options
+    | are documented at:
+    | http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html
+    |
+    */
+
+    'region' => env('AWS_REGION', 'us-east-1'),
+    'version' => 'latest',
+    'ua_append' => [
+        'L5MOD/'.AwsServiceProvider::VERSION,
+    ],
+];

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -48,36 +48,18 @@ return [
             'root'   => storage_path('app'),
         ],
 
-        'ftp' => [
-            'driver'   => 'ftp',
-            'host'     => 'ftp.example.com',
-            'username' => 'your-username',
-            'password' => 'your-password',
-
-            // Optional FTP Settings...
-            // 'port'     => 21,
-            // 'root'     => '',
-            // 'passive'  => true,
-            // 'ssl'      => true,
-            // 'timeout'  => 30,
+        'public' => [
+            'driver' => 'local',
+            'root'   => storage_path('app/public'),
+            'visibility' => 'public',
         ],
 
         's3' => [
             'driver' => 's3',
-            'key'    => 'your-key',
-            'secret' => 'your-secret',
-            'region' => 'your-region',
-            'bucket' => 'your-bucket',
-        ],
-
-        'rackspace' => [
-            'driver'    => 'rackspace',
-            'username'  => 'your-username',
-            'key'       => 'your-key',
-            'container' => 'your-container',
-            'endpoint'  => 'https://identity.api.rackspacecloud.com/v2.0/',
-            'region'    => 'IAD',
-            'url_type'  => 'publicURL',
+            'key'    => env('S3_KEY'),
+            'secret' => env('S3_SECRET'),
+            'region' => env('S3_REGION'),
+            'bucket' => env('S3_BUCKET'),
         ],
 
     ],

--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -1,0 +1,153 @@
+<?php
+
+return [
+
+    'backup' => [
+
+        /*
+         * The name of this application. You can use this name to monitor
+         * the backups.
+         */
+        'name' => env('APP_URL'),
+
+        'source' => [
+
+            'files' => [
+
+                /*
+                 * The list of directories that should be part of the backup. You can
+                 * specify individual files as well.
+                 */
+                'include' => [
+                    base_path(),
+                ],
+
+                /*
+                 * These directories will be excluded from the backup.
+                 * You can specify individual files as well.
+                 */
+                'exclude' => [
+                    base_path('vendor'),
+                    base_path('node_modules'),
+                    storage_path(),
+                ],
+
+                /*
+                 * Determines if symlinks should be followed.
+                 */
+                'followLinks' => true,
+            ],
+
+            /*
+             * The names of the connections to the databases that should be part of the backup.
+             * Currently only MySQL- and PostgreSQL-databases are supported.
+             */
+            'databases' => [
+                'mysql',
+            ],
+        ],
+
+        'destination' => [
+
+            /*
+             * The disk names on which the backups will be stored.
+             */
+            'disks' => [
+                's3',
+                'local',
+            ],
+        ],
+    ],
+
+    'cleanup' => [
+        /*
+         * The strategy that will be used to cleanup old backups.
+         * The youngest backup will never be deleted.
+         */
+        'strategy' => \Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy::class,
+
+        'defaultStrategy' => [
+
+            /*
+             * The amount of days that all backups must be kept.
+             */
+            'keepAllBackupsForDays' => 7,
+
+            /*
+             * The amount of days that all daily backups must be kept.
+             */
+            'keepDailyBackupsForDays' => 30,
+
+            /*
+             * The amount of weeks of which one weekly backup must be kept.
+             */
+            'keepWeeklyBackupsForWeeks' => 8,
+
+            /*
+             * The amount of months of which one monthly backup must be kept.
+             */
+            'keepMonthlyBackupsForMonths' => 4,
+
+            /*
+             * The amount of years of which one yearly backup must be kept.
+             */
+            'keepYearlyBackupsForYears' => 2,
+
+            /*
+             * After cleaning up the backups remove the oldest backup until
+             * this amount of megabytes has been reached.
+             */
+
+            'deleteOldestBackupsWhenUsingMoreMegabytesThan' => 5000,
+        ],
+    ],
+
+
+    /*
+     *  In this array you can specify which backups should be monitored.
+     *  If a backup does not meet the specified requirements the
+     *  UnHealthyBackupWasFound-event will be fired.
+     */
+    'monitorBackups' => [
+        [
+            'name' => env('APP_URL'),
+            'disks' => ['s3'],
+            'newestBackupsShouldNotBeOlderThanDays' => 1,
+            'storageUsedMayNotBeHigherThanMegabytes' => 5000,
+        ],
+
+    ],
+
+    'notifications' => [
+
+        /*
+         * This class will be used to send all notifications.
+         */
+        'handler' => Spatie\Backup\Notifications\Notifier::class,
+
+        /*
+         * Here you can specify the ways you want to be notified when certain
+         * events take place. Possible values are "log", "mail", "slack" and "pushover".
+         *
+         * Slack requires the installation of the maknz/slack package.
+         */
+        'events' => [
+            'whenBackupWasSuccessful'     => ['log'],
+            'whenCleanupWasSuccessful'    => ['log'],
+            'whenHealthyBackupWasFound'   => ['log'],
+            'whenBackupHasFailed'         => ['log', 'slack'],
+            'whenCleanupHasFailed'        => ['log'],
+            'whenUnhealthyBackupWasFound' => ['log', 'slack'],
+        ],
+
+        /*
+         * Here you can specify how messages should be sent to Slack.
+         */
+        'slack' => [
+            'channel'  => '#devops',
+            'username' => 'Aurora Backup Bot',
+            'icon'     => ':robot:',
+        ],
+
+    ],
+];

--- a/config/slack.php
+++ b/config/slack.php
@@ -1,0 +1,122 @@
+<?php
+
+return [
+
+    /*
+    |-------------------------------------------------------------
+    | Incoming webhook endpoint
+    |-------------------------------------------------------------
+    |
+    | The endpoint which Slack generates when creating a
+    | new incoming webhook. It will look something like
+    | https://hooks.slack.com/services/XXXXXXXX/XXXXXXXX/XXXXXXXXXXXXXX
+    |
+    */
+
+    'endpoint' => env('SLACK_ENDPOINT'),
+
+    /*
+    |-------------------------------------------------------------
+    | Default channel
+    |-------------------------------------------------------------
+    |
+    | The default channel we should post to. The channel can either be a
+    | channel like #general, a private #group, or a @username. Set to
+    | null to use the default set on the Slack webhook
+    |
+    */
+
+    'channel' => '#devops',
+
+    /*
+    |-------------------------------------------------------------
+    | Default username
+    |-------------------------------------------------------------
+    |
+    | The default username we should post as. Set to null to use
+    | the default set on the Slack webhook
+    |
+    */
+
+    'username' => 'AuroraRobot',
+
+    /*
+    |-------------------------------------------------------------
+    | Default icon
+    |-------------------------------------------------------------
+    |
+    | The default icon to use. This can either be a URL to an image or Slack
+    | emoji like :ghost: or :heart_eyes:. Set to null to use the default
+    | set on the Slack webhook
+    |
+    */
+
+    'icon' => null,
+
+    /*
+    |-------------------------------------------------------------
+    | Link names
+    |-------------------------------------------------------------
+    |
+    | Whether names like @regan should be converted into links
+    | by Slack
+    |
+    */
+
+    'link_names' => false,
+
+    /*
+    |-------------------------------------------------------------
+    | Unfurl links
+    |-------------------------------------------------------------
+    |
+    | Whether Slack should unfurl links to text-based content
+    |
+    */
+
+    'unfurl_links' => false,
+
+    /*
+    |-------------------------------------------------------------
+    | Unfurl media
+    |-------------------------------------------------------------
+    |
+    | Whether Slack should unfurl links to media content such
+    | as images and YouTube videos
+    |
+    */
+
+    'unfurl_media' => true,
+
+    /*
+    |-------------------------------------------------------------
+    | Markdown in message text
+    |-------------------------------------------------------------
+    |
+    | Whether message text should be interpreted in Slack's Markdown-like
+    | language. For formatting options, see Slack's help article: http://goo.gl/r4fsdO
+    |
+    */
+
+    'allow_markdown' => true,
+
+    /*
+    |-------------------------------------------------------------
+    | Markdown in attachments
+    |-------------------------------------------------------------
+    |
+    | Which attachment fields should be interpreted in Slack's Markdown-like
+    | language. By default, Slack assumes that no fields in an attachment
+    | should be formatted as Markdown.
+    |
+    */
+
+    'markdown_in_attachments' => [],
+
+    // Allow Markdown in just the text and title fields
+    // 'markdown_in_attachments' => ['text', 'title']
+
+    // Allow Markdown in all fields
+    // 'markdown_in_attachments' => ['pretext', 'text', 'title', 'fields', 'fallback']
+
+];


### PR DESCRIPTION
#### What's this PR do?
I've added the packages to support Laravel backups.

#### How should this be manually tested?
Once on QA, you can run php artisan backup:run. The reason it can't be run locally is because the settings require s3 credentials that devs won't have on their local machines.

#### Any background context you want to provide?
This is part of the disaster recovery efforts, and will make backing up via Jenkins job much easier.