### PR TITLE
Make a separate cached query for total count.

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -32,13 +32,19 @@ class UsersController extends Controller
      */
     public function index(Request $request)
     {
+        // Cache the total user count for 15 minutes so we can make fast cursor-based
+        // queries, but still show the total number of records to admins.
+        $total = remember('users.count', 15, function () {
+            return gateway('northstar')->getAllUsers()->total();
+        });
+
         $inputs = array_merge($request->all(), ['pagination' => 'cursor']);
         $users = $this->northstar->getAllUsers($inputs);
         $users->setPaginator(Paginator::class, [
             'path' => 'users',
         ]);
 
-        return view('users.index', compact('users'));
+        return view('users.index', compact('users', 'total'));
     }
 
     /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -37,3 +37,16 @@ function markdown($source)
 
     return new HtmlString($markup);
 }
+
+/**
+ * Get an item from the cache, or store the default value.
+ *
+ * @param  string  $key
+ * @param  \DateTime|float|int  $minutes
+ * @param  \Closure  $callback
+ * @return mixed
+ */
+function remember($key, $minutes, Closure $callback)
+{
+    return app('cache')->remember($key, $minutes, $callback);
+}

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -8,7 +8,7 @@
   <div class="wrapper">
       <div class="container__block">
           <h1>All Users</h1>
-          <p>We currently have <strong>{{ number_format($users->total()) }} members</strong> in Northstar.</p>
+          <p>We currently have <strong>{{ number_format($total) }} users</strong> in Northstar.</p>
           @include('search.search')
       </div>
 


### PR DESCRIPTION
Since we switched to using cursor pagination, we get the wrong user count in the "intro" text. Let's make a separate query to find this out and cache it for future page views.

![screen shot 2017-10-18 at 2 44 52 pm](https://user-images.githubusercontent.com/583202/31736487-eaca08e2-b412-11e7-8063-ed506e6db640.png)


🔢