### PR TITLE
Fix fatal error on unauthorized page.

### DIFF
--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -41,7 +41,7 @@ class CheckRole
             if ($request->ajax()) {
                 return response('Unauthorized.', 401);
             } else {
-                return view('auth.unauthorized');
+                return response()->view('auth.unauthorized');
             }
         }
 


### PR DESCRIPTION
### Changes
You can no longer return a `Illuminate\View\View` directly from middleware in Laravel 5.2+, so this was causing a rather nasty Whoops error. Instead, use the `response()` helper to create an actual `Illuminate\Http\Response`.