### PR TITLE
Lazy load the user count on the index page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ $ composer install && npm install
 # Copy the default environment variables:
 $ cp .env.example .env
 
-# Make app key & run database migrations:
+# Make app key, get Northstar public key, & run migrations:
 $ php artisan key:generate
+$ php artisan gateway:key
 $ php artisan migrate
 
 # And finally, build the frontend assets:

--- a/app/Http/Controllers/Api/TotalsController.php
+++ b/app/Http/Controllers/Api/TotalsController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Aurora\Http\Controllers\Api;
+
+use Aurora\Http\Controllers\Controller;
+
+class TotalsController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth:api');
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return array
+     */
+    public function index()
+    {
+        // Cache the total user count for 15 minutes so we can make fast cursor-based
+        // queries, but still show the total number of records to admins.
+        $total = remember('users.count.'.auth()->id(), 15, function () {
+            return gateway('northstar')->withToken(token())->getAllUsers()->total();
+        });
+
+        return ['total' => number_format($total)];
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -50,3 +50,15 @@ function remember($key, $minutes, Closure $callback)
 {
     return app('cache')->remember($key, $minutes, $callback);
 }
+
+/**
+ * Create a script tag to set a global variable.
+ *
+ * @param $json
+ * @param string $store
+ * @return HtmlString
+ */
+function scriptify($json = [], $store = 'STATE')
+{
+    return new HtmlString('<script type="text/javascript">window.'.$store.' = '.json_encode($json).'</script>');
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "require": {
         "php": ">=7.0.0",
         "doctrine/dbal": "^2.5",
-        "dosomething/gateway": "^1.9.0",
+        "dosomething/gateway": "v1.9.3",
         "erusev/parsedown": "^1.6",
         "fideloper/proxy": "^3.3",
         "guzzlehttp/guzzle": "~6.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "58318abff633503aaaa4c92354ca576e",
+    "content-hash": "242b2c350facb6e312e405c3a1b17981",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.36.28",
+            "version": "3.36.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "65ca98c303ea1489b2719b6d892d800dd604d4b2"
+                "reference": "356d36a46e5cfd2f061fa33a5604fa8ab7acf4f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/65ca98c303ea1489b2719b6d892d800dd604d4b2",
-                "reference": "65ca98c303ea1489b2719b6d892d800dd604d4b2",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/356d36a46e5cfd2f061fa33a5604fa8ab7acf4f2",
+                "reference": "356d36a46e5cfd2f061fa33a5604fa8ab7acf4f2",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-10-17T19:51:40+00:00"
+            "time": "2017-10-19T17:42:39+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -591,16 +591,16 @@
         },
         {
             "name": "dosomething/gateway",
-            "version": "v1.9.1",
+            "version": "v1.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "c1250977bd1ec99201af5fd92c468586b68fd8c3"
+                "reference": "e5115ed02017c48b77a790a2ce69ca22e84aadcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/c1250977bd1ec99201af5fd92c468586b68fd8c3",
-                "reference": "c1250977bd1ec99201af5fd92c468586b68fd8c3",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/e5115ed02017c48b77a790a2ce69ca22e84aadcf",
+                "reference": "e5115ed02017c48b77a790a2ce69ca22e84aadcf",
                 "shasum": ""
             },
             "require": {
@@ -639,7 +639,7 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2017-10-18T18:11:37+00:00"
+            "time": "2017-10-20T16:34:28+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -1231,16 +1231,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.5.17",
+            "version": "v5.5.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "3a16d196bd8d2b7761c9b0060a30a3687c3ea201"
+                "reference": "1cc21baac11551377734b8c17ead17db4c34fe21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/3a16d196bd8d2b7761c9b0060a30a3687c3ea201",
-                "reference": "3a16d196bd8d2b7761c9b0060a30a3687c3ea201",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/1cc21baac11551377734b8c17ead17db4c34fe21",
+                "reference": "1cc21baac11551377734b8c17ead17db4c34fe21",
                 "shasum": ""
             },
             "require": {
@@ -1281,7 +1281,6 @@
                 "illuminate/database": "self.version",
                 "illuminate/encryption": "self.version",
                 "illuminate/events": "self.version",
-                "illuminate/exception": "self.version",
                 "illuminate/filesystem": "self.version",
                 "illuminate/hashing": "self.version",
                 "illuminate/http": "self.version",
@@ -1359,7 +1358,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2017-10-17T12:19:22+00:00"
+            "time": "2017-10-19T12:50:26+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -2361,16 +2360,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.8.12",
+            "version": "v0.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "1502354ebc70d59d8e3a87c325b0eb78a79da25b"
+                "reference": "cdb5593c3684bab74e10fcfffe4a0c8d1c39695d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/1502354ebc70d59d8e3a87c325b0eb78a79da25b",
-                "reference": "1502354ebc70d59d8e3a87c325b0eb78a79da25b",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/cdb5593c3684bab74e10fcfffe4a0c8d1c39695d",
+                "reference": "cdb5593c3684bab74e10fcfffe4a0c8d1c39695d",
                 "shasum": ""
             },
             "require": {
@@ -2430,7 +2429,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2017-10-14T17:14:13+00:00"
+            "time": "2017-10-19T06:13:20+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -3976,37 +3975,40 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -4014,7 +4016,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/config/auth.php
+++ b/config/auth.php
@@ -38,12 +38,12 @@ return [
     'guards' => [
         'web' => [
             'driver' => 'session',
-            'provider' => 'users',
+            'provider' => 'local',
         ],
 
         'api' => [
-            'driver' => 'token',
-            'provider' => 'users',
+            'driver' => 'gateway',
+            'provider' => 'northstar',
         ],
     ],
 
@@ -67,9 +67,13 @@ return [
     'model' => Aurora\Models\AuroraUser::class,
 
     'providers' => [
-        'users' => [
+        'local' => [
             'driver' => 'eloquent',
             'model' => Aurora\Models\AuroraUser::class,
+        ],
+
+        'northstar' => [
+            'driver' => 'gateway',
         ],
     ],
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ ssh_options[:keys] = [ENV["CAP_PRIVATE_KEY"]]
 default_run_options[:shell] = '/bin/bash'
 
 namespace :deploy do
-  folders = %w{logs dumps system}
+  folders = %w{logs dumps system keys}
 
   task :link_folders do
     run "ln -nfs #{shared_path}/.env #{release_path}/"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,6 +30,7 @@ namespace :deploy do
     run "ln -nfs #{shared_path}/.env #{release_path}/"
 
     folders.each do |folder|
+      run "rm -rf #{release_path}/storage/#{folder}"
       run "ln -nfs #{shared_path}/#{folder} #{release_path}/storage/#{folder}"
     end
   end

--- a/config/services.php
+++ b/config/services.php
@@ -17,6 +17,7 @@ return [
     'northstar' => [
         'grant' => 'authorization_code',
         'url' => env('NORTHSTAR_URL'),
+        'key' => storage_path('keys/public.key'),
         'authorization_code' => [
             'client_id' => env('NORTHSTAR_CLIENT_ID'),
             'client_secret' => env('NORTHSTAR_CLIENT_SECRET'),

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -10,10 +10,16 @@ import confirm from './utilities/confirm';
 import formLoader from './utilities/form-loader';
 import methodLink from './utilities/method-link';
 
+// Users
+import lazyCount from './users/lazy-user-count';
+
 /**
  * Let's go!
  */
 ready(function() {
+  // Lazy-load user count in the background.
+  lazyCount.initialize();
+
   // Initialize `data-confirm` link handler.
   confirm.initialize();
 

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -9,6 +9,7 @@ $forge-path: "~@dosomething/forge/assets/";
 @import "components/button";
 @import "components/danger-zone";
 @import "components/form-item";
+@import "components/lazy-loading";
 @import "components/profile-settings";
 @import "components/table";
 @import "components/validation-error";

--- a/resources/assets/components/lazy-loading.scss
+++ b/resources/assets/components/lazy-loading.scss
@@ -1,0 +1,15 @@
+@keyframes pulse {
+  0% { color: #666; }
+  50% { color: #ddd; }
+  100% { color: #666; }
+}
+
+.lazy-loading {
+  animation: pulse 3s infinite;
+  transition: color 1s;
+}
+
+.lazy-loading.is-loaded {
+  color: inherit !important;
+  animation: none;
+}

--- a/resources/assets/users/lazy-user-count.js
+++ b/resources/assets/users/lazy-user-count.js
@@ -1,0 +1,21 @@
+import { RestApiClient } from '@dosomething/gateway';
+
+/**
+ * Lazy load user count if it's on the page.
+ */
+async function initialize() {
+  const element = document.getElementById('lazy-user-count');
+  if (! element) {
+    return;
+  }
+
+  const aurora = new RestApiClient(window.location.origin, {
+    headers: { 'Authorization' : `Bearer ${window.AUTH}`}
+  });
+
+  const response = await aurora.get('api/total');
+  element.innerText = response ? response['total'] : '???';
+  element.classList = 'lazy-loading is-loaded';
+}
+
+export default { initialize };

--- a/resources/views/layout/master.blade.php
+++ b/resources/views/layout/master.blade.php
@@ -26,6 +26,7 @@
 </div>
 </body>
 
+{{ scriptify(auth()->user() ? auth()->user()->access_token : null, 'AUTH') }}
 
 <script src="{{ elixir('app.js', 'dist') }}"></script>
 

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -8,7 +8,7 @@
   <div class="wrapper">
       <div class="container__block">
           <h1>All Users</h1>
-          <p>We currently have <strong>{{ number_format($total) }} users</strong> in Northstar.</p>
+          <p>We currently have <strong><span id="lazy-user-count" class="lazy-loading">#,###,###</span> users</strong> in Northstar.</p>
           @include('search.search')
       </div>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,7 +9,5 @@
  * @see \Aurora\Providers\RouteServiceProvider
  */
 
-// Health Check
-$router->get('/status', function () {
-    return response()->json(['status' => true]);
-});
+// Total User Count
+$router->get('/total', 'Api\TotalsController@index');

--- a/storage/keys/.gitignore
+++ b/storage/keys/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
### Changes

This pull request adds lazy-loading for the user count on the index page.

![screen recording 2017-10-20 at 02 39 pm](https://user-images.githubusercontent.com/583202/31836814-8c08dc50-b5a4-11e7-9589-2bd7fcf3c452.gif)


📄 Adds `scriptify` helper & uses it to expose user's access token to scripts. 6060360

🤖 Configures Northstar resource server using Gateway. 81f0ed6

#️⃣ Adds a API route for the user count, and a little front-end widget to show it. ce1b6e0

This is _totally_ over-engineered for the use case, but is intended a little proof-of-concept for doing the same thing in Rogue and other applications in the future. Since this endpoint is secured using a Northstar token, it could be used by any other application, in addition to Aurora web requests!