### PR TITLE
temp removing ConvertEmptyStringsToNull middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,7 +16,8 @@ class Kernel extends HttpKernel
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
-        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        // @TODO: Re-add once 'nullable' validation is fixed in Northstar.
+        // \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \Aurora\Http\Middleware\TrimStrings::class,
         \Aurora\Http\Middleware\TrustProxies::class,
     ];


### PR DESCRIPTION
- fixes issue in user edit form where `ConvertEmptyStringsToNull` middleware sends `null` value to Northstar which we haven't properly dealt with yet there, so it wrongfully validates the empty field. We'll re-add once that's addressed.