### PR TITLE
Remove the synchronous call to get user total.

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -32,19 +32,13 @@ class UsersController extends Controller
      */
     public function index(Request $request)
     {
-        // Cache the total user count for 15 minutes so we can make fast cursor-based
-        // queries, but still show the total number of records to admins.
-        $total = remember('users.count', 15, function () {
-            return gateway('northstar')->getAllUsers()->total();
-        });
-
         $inputs = array_merge($request->all(), ['pagination' => 'cursor']);
         $users = $this->northstar->getAllUsers($inputs);
         $users->setPaginator(Paginator::class, [
             'path' => 'users',
         ]);
 
-        return view('users.index', compact('users', 'total'));
+        return view('users.index', compact('users'));
     }
 
     /**


### PR DESCRIPTION
I noticed that page loads were still occasionally very slow, and it's because I never removed this API call from the controller (so every 15 minutes, we'd delay the request to make a full load of that count). Oy!

References #170.