### PR TITLE
uncommenting the ConvertEmptyStringsToNull middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,8 +16,7 @@ class Kernel extends HttpKernel
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
-        // @TODO: Re-add once 'nullable' validation is fixed in Northstar.
-        // \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \Aurora\Http\Middleware\TrimStrings::class,
         \Aurora\Http\Middleware\TrustProxies::class,
     ];


### PR DESCRIPTION
Since @DFurnes updated Northstar to deal with null values in validation, we can revive this piece of middleware 🍾 