### PR TITLE
removing faulty view argument

### DIFF
--- a/resources/views/users/search.blade.php
+++ b/resources/views/users/search.blade.php
@@ -15,7 +15,7 @@
       <div class="container__block">
           @if ($users)
               @include('users.partials.index-table', ['users' => $users])
-              {!! $users->links(\Aurora\Http\Presenters\ForgePaginationPresenter::class) !!}
+              {!! $users->links() !!}
           @endif
       </div>
 


### PR DESCRIPTION
Part of the update to Laravel 5.5. We don't need that view argument anymore.
https://dosomething.slack.com/archives/C02BBRN5A/p1510863519000167