### PR TITLE
Update dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2336,11 +2336,11 @@
       "dev": true
     },
     "dosomething-modal": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/dosomething-modal/-/dosomething-modal-0.3.3.tgz",
-      "integrity": "sha1-pw2Dhn+V//xvN9NgzobpRXqkc3o=",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/dosomething-modal/-/dosomething-modal-0.3.4.tgz",
+      "integrity": "sha512-S1a2CK2TgysOwFGCzEkk9EQvXyWAWhBrOLIM8uyir+dAclapHYm+/vuReBAx85DWtsW0O9N7DMjUA1rypvC68A==",
       "requires": {
-        "jquery": "1.12.4"
+        "jquery": "3.3.1"
       }
     },
     "ecc-jsbn": {
@@ -4445,9 +4445,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
-      "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "js-base64": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@dosomething/gateway": "^1.1.5",
     "babel-polyfill": "^6.26.0",
     "dom-delegate": "^2.0.3",
-    "dosomething-modal": "^0.3.0"
+    "dosomething-modal": "^0.3.4"
   },
   "devDependencies": {
     "@dosomething/webpack-config": "^2.0.4",


### PR DESCRIPTION
The `dosomething-modal` dependency was still dragging us down to jQuery 1.12. ⬇️ 