### PR TITLE
Fix issue where machine clients would 422.

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -80,6 +80,9 @@ class ClientController extends Controller
 
         // Transform 'redirect_uri' from a CSV into an array of strings.
         $parameters['redirect_uri'] = csv_to_array($parameters['redirect_uri']);
+        if ($parameters['allowed_grant'] === 'client_credentials') {
+            unset($parameters['redirect_uri']);
+        }
 
         $this->northstar->createNewClient($parameters);
 
@@ -114,6 +117,9 @@ class ClientController extends Controller
 
         // Transform 'redirect_uri' from a CSV into an array of strings.
         $parameters['redirect_uri'] = csv_to_array($parameters['redirect_uri']);
+        if ($parameters['allowed_grant'] === 'client_credentials') {
+            unset($parameters['redirect_uri']);
+        }
 
         // Ensure that all scopes can be removed from a client.
         $parameters['scope'] = ! empty($parameters['scope']) ? $parameters['scope'] : [];


### PR DESCRIPTION
### Changes
This fixes a little error that was preventing me from creating new machine clients via the Aurora admin interface. The `csv_to_array` function above would output an array with a single empty string, which would fail [Northstar's `url` validation rule](https://github.com/DoSomething/northstar/blob/4737f01745acaecccdf5ccedf1db3c67fa7911d0/app/Http/Controllers/ClientController.php#L93).