### PR TITLE
Add client scope for Northstar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ CACHE_DRIVER=file
 SESSION_DRIVER=file
 QUEUE_DRIVER=sync
 
-NORTHSTAR_URL=http://northstar.dev
+NORTHSTAR_URL=http://northstar.test
 NORTHSTAR_CLIENT_ID=oauth-test-client
 NORTHSTAR_CLIENT_SECRET=secret1
 

--- a/app/Console/Commands/SetupCommand.php
+++ b/app/Console/Commands/SetupCommand.php
@@ -34,7 +34,7 @@ class SetupCommand extends Command
 
         $this->section('Set Northstar environment variables', function () {
             $environments = [
-                'http://northstar.dev',
+                'http://northstar.test',
                 'https://northstar-qa.dosomething.org',
                 'https://northstar-thor.dosomething.org',
             ];

--- a/config/services.php
+++ b/config/services.php
@@ -20,7 +20,7 @@ return [
         'authorization_code' => [
             'client_id' => env('NORTHSTAR_CLIENT_ID'),
             'client_secret' => env('NORTHSTAR_CLIENT_SECRET'),
-            'scope' => ['role:admin', 'role:staff', 'user', 'openid'],
+            'scope' => ['role:admin', 'role:staff', 'user', 'openid', 'client'],
             'redirect_uri' => 'auth/login',
         ],
     ],


### PR DESCRIPTION
1. Locally we now use `northstar.test` so swap out our `northstar.dev` references for that.
2. Add the `client` scope to the Northstar credentials.