### PR TITLE
Some adjustments for better concurrency.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,3 @@
-# Increase request size limit.
-client_max_body_size 10M;
-
 # Serve application with Laravel.
 # see: https://laravel.com/docs/5.5/installation#web-server-configuration
 location / {

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,0 +1,1 @@
+memory_limit=32M


### PR DESCRIPTION
Investigating why this always gets set to `WEB_CONCURRENCY=1`. Neither of these changes did anything, but reducing our per-process memory limit should let us spin up more processes per dyno.

References DoSomething/devops#427.