### PR TITLE
Update links to Northstar Auth docs

### DIFF
--- a/resources/views/clients/index.blade.php
+++ b/resources/views/clients/index.blade.php
@@ -9,7 +9,7 @@
       <div class="container__block -narrow">
           <div class="gallery__heading"><h1>All Clients</h1></div>
           <p>These are the OAuth clients registered in Northstar and the permissions they have been given. Tokens can be
-             used to <a href="https://git.io/vdXBk">authorize requests</a> to any compatible DoSomething.org services.</p>
+             used to <a href="https://git.io/fN6yC">authorize requests</a> to any compatible DoSomething.org services.</p>
       </div>
       <ul class="gallery -duo">
           @forelse($clients as $client)

--- a/resources/views/clients/show.blade.php
+++ b/resources/views/clients/show.blade.php
@@ -20,7 +20,7 @@
                     using the <a href="https://git.io/vduUZ">Authorization Code grant</a>.</p>
                 @elseif($client->allowed_grant == 'client_credentials')
                     <p>This is a machine client that requests tokens via the
-                    <a href="https://git.io/vduUC">Client Credentials grant</a>.</p>
+                    <a href="https://git.io/fN6yP">Client Credentials grant</a>.</p>
                 @else
                     <p>This client uses the <code>'{{ $client->allowed_grant }}'</code> grant.</p>
                 @endif


### PR DESCRIPTION
I was messing around with some clients and bumped into two broken links (remnants of the `dev` branch era). Updated 'em!

