### PR TITLE
Disable nginx access logs.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,3 +4,7 @@ location / {
     index index.php;
     try_files $uri $uri/ /index.php?$query_string;
 }
+
+# Disable nginx's access log since we get the same information
+# from Heroku's router (and can more easily filter that).
+access_log off;


### PR DESCRIPTION
#### What's this PR do?
This pull request disable's nginx's access logs for Aurora, since we get similar information in a more readable format from [Heroku's router](https://devcenter.heroku.com/articles/http-routing#heroku-router-log-format). This should help trim down log usage even further.

#### How should this be reviewed?
I've deployed the [same change](https://github.com/DoSomething/northstar/pull/786) to Northstar QA & verified that access logs are disabled.

#### Relevant Tickets
References DoSomething/devops#432.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  