### PR TITLE
Surface voter registration status in Aurora

### DIFF
--- a/app/Services/Fastly.php
+++ b/app/Services/Fastly.php
@@ -99,11 +99,11 @@ class Fastly extends RestApiClient
     {
         // Update the corresponding record in the redirects & statuses dictionaries.
         $redirect = $this->patch('dictionary/'.$this->redirects.'/item/'.urlencode($path), [
-            'item_value' => $target
+            'item_value' => $target,
         ]);
 
         $type = $this->patch('dictionary/'.$this->types.'/item/'.urlencode($path), [
-            'item_value' => $status
+            'item_value' => $status,
         ]);
 
         return Redirect::fromItems($redirect, $type);

--- a/resources/views/users/partials/profile.blade.php
+++ b/resources/views/users/partials/profile.blade.php
@@ -16,3 +16,4 @@
 <dt>SMS Paused:</dt><dd>{{ $user->sms_paused ? '✔' : '✘' }}</dd>
 <dt>Country:</dt><dd>{{ $user->country or '&mdash;' }}</dd>
 <dt>Role:</dt><dd>{{ $user->role or '&mdash;' }}</dd>
+<dt>Voter Registration Status:</dt><dd>{{ $user->voter_registration_status or '&mdash;' }}</dd>


### PR DESCRIPTION
#### What's this PR do?
Surfaces `voter_registration_status` on a user in Aurora.

Looks like this (don't worry, randomly generated test user!):
![image](https://user-images.githubusercontent.com/4240292/46166926-3e64e180-c249-11e8-822b-301d52acd3e1.png)


#### How should this be reviewed?
We want this?

#### Relevant Tickets
🤠 
