### PR TITLE
Add commands to import/export from Fastly, and some admin updates.

### DIFF
--- a/app/Console/Commands/FastlyExportCommand.php
+++ b/app/Console/Commands/FastlyExportCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Aurora\Console\Commands;
+
+use Aurora\Services\Fastly;
+use Illuminate\Console\Command;
+
+class FastlyExportCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'fastly:export';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Export Fastly dictionaries from this app\'s service.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(Fastly $fastly)
+    {
+        $redirects = $fastly->getAllRedirects();
+        $this->line(json_encode($redirects, JSON_PRETTY_PRINT));
+    }
+}

--- a/app/Console/Commands/FastlyImportCommand.php
+++ b/app/Console/Commands/FastlyImportCommand.php
@@ -36,13 +36,12 @@ class FastlyImportCommand extends Command
         }, json_decode($input, true));
 
         $url = config('services.fastly.service_url');
-        $confirmation = 'Would you like to create ' . count($redirects) . ' redirects on ' . $url . '?';
+        $confirmation = 'Would you like to create '.count($redirects).' redirects on '.$url.'?';
         if ($this->confirm($confirmation)) {
             foreach ($redirects as $redirect) {
-                $this->line('Redirecting "' . $redirect->path . '" to "' . $redirect->target . '" (' . $redirect->status . ')');
+                $this->line('Redirecting "'.$redirect->path.'" to "'.$redirect->target.'" ('.$redirect->status.')');
                 $fastly->createRedirect($redirect->path, $redirect->target, $redirect->status);
             }
         }
-
     }
 }

--- a/app/Console/Commands/FastlyImportCommand.php
+++ b/app/Console/Commands/FastlyImportCommand.php
@@ -38,13 +38,10 @@ class FastlyImportCommand extends Command
         $url = config('services.fastly.service_url');
         $confirmation = 'Would you like to create ' . count($redirects) . ' redirects on ' . $url . '?';
         if ($this->confirm($confirmation)) {
-            $progress = $this->output->createProgressBar(count($redirects));
             foreach ($redirects as $redirect) {
+                $this->line('Redirecting "' . $redirect->path . '" to "' . $redirect->target . '" (' . $redirect->status . ')');
                 $fastly->createRedirect($redirect->path, $redirect->target, $redirect->status);
-                $progress->advance();
             }
-
-            $progress->finish();
         }
 
     }

--- a/app/Console/Commands/FastlyImportCommand.php
+++ b/app/Console/Commands/FastlyImportCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Aurora\Console\Commands;
+
+use Aurora\Services\Fastly;
+use Aurora\Resources\Redirect;
+use Illuminate\Console\Command;
+
+class FastlyImportCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'fastly:import {path}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import Fastly dictionaries to this app\'s service.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(Fastly $fastly)
+    {
+        $input = file_get_contents($this->argument('path'));
+
+        $redirects = array_map(function ($redirect) {
+            return new Redirect($redirect);
+        }, json_decode($input, true));
+
+        $url = config('services.fastly.service_url');
+        $confirmation = 'Would you like to create ' . count($redirects) . ' redirects on ' . $url . '?';
+        if ($this->confirm($confirmation)) {
+            $progress = $this->output->createProgressBar(count($redirects));
+            foreach ($redirects as $redirect) {
+                $fastly->createRedirect($redirect->path, $redirect->target, $redirect->status);
+                $progress->advance();
+            }
+
+            $progress->finish();
+        }
+
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -8,15 +8,6 @@ use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 class Kernel extends ConsoleKernel
 {
     /**
-     * The Artisan commands provided by your application.
-     *
-     * @var array
-     */
-    protected $commands = [
-        \Aurora\Console\Commands\SetupCommand::class,
-    ];
-
-    /**
      * Define the application's command schedule.
      *
      * @param  \Illuminate\Console\Scheduling\Schedule  $schedule

--- a/app/Http/Controllers/RedirectsController.php
+++ b/app/Http/Controllers/RedirectsController.php
@@ -74,9 +74,11 @@ class RedirectsController extends Controller
     public function store(Request $request)
     {
         $this->validate($request, [
-            'path' => 'required|string',
+            'path' => 'required|string|regex:/^[^?]+$/',
             'target' => 'required|url',
             'status' => 'required|in:301,302',
+        ], [
+            'path.regex' => 'Paths cannot contain query strings.'
         ]);
 
         $redirect = $this->fastly->createRedirect($request->path, $request->target, $request->status);

--- a/app/Http/Controllers/RedirectsController.php
+++ b/app/Http/Controllers/RedirectsController.php
@@ -78,7 +78,7 @@ class RedirectsController extends Controller
             'target' => 'required|url',
             'status' => 'required|in:301,302',
         ], [
-            'path.regex' => 'Paths cannot contain query strings.'
+            'path.regex' => 'Paths cannot contain query strings.',
         ]);
 
         $redirect = $this->fastly->createRedirect($request->path, $request->target, $request->status);

--- a/app/Resources/Redirect.php
+++ b/app/Resources/Redirect.php
@@ -3,9 +3,10 @@
 namespace Aurora\Resources;
 
 use Carbon\Carbon;
+use JsonSerializable;
 use DoSomething\Gateway\Common\ApiResponse;
 
-class Redirect extends ApiResponse
+class Redirect extends ApiResponse implements JsonSerializable
 {
     /**
      * Create a new redirect from the given API response.
@@ -60,5 +61,15 @@ class Redirect extends ApiResponse
     public static function decodeId($id)
     {
         return urlencode(base64_decode(str_replace('_', '/', $id)));
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->attributes;
     }
 }

--- a/app/Resources/RedirectCollection.php
+++ b/app/Resources/RedirectCollection.php
@@ -2,12 +2,23 @@
 
 namespace Aurora\Resources;
 
+use JsonSerializable;
 use DoSomething\Gateway\Common\ApiCollection;
 
-class RedirectCollection extends ApiCollection
+class RedirectCollection extends ApiCollection implements JsonSerializable
 {
     public function __construct($response)
     {
         parent::__construct($response, Redirect::class);
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
     }
 }

--- a/app/Services/Fastly.php
+++ b/app/Services/Fastly.php
@@ -75,15 +75,13 @@ class Fastly extends RestApiClient
             $path = '/'.$path;
         }
 
-        // Create a record in the redirects dictionary.
-        $redirect = $this->post('dictionary/'.$this->redirects.'/item', [
-            'item_key' => $path,
+        // Create or update a record in the redirects dictionary.
+        $redirect = $this->put('dictionary/'.$this->redirects.'/item/'.$path, [
             'item_value' => $target,
         ]);
 
-        // Create a record in the statuses dictionary.
-        $type = $this->post('dictionary/'.$this->types.'/item', [
-            'item_key' => $path,
+        // Create or update a record in the statuses dictionary.
+        $type = $this->put('dictionary/'.$this->types.'/item/'.$path, [
             'item_value' => $status,
         ]);
 

--- a/app/Services/Fastly.php
+++ b/app/Services/Fastly.php
@@ -70,9 +70,9 @@ class Fastly extends RestApiClient
      */
     public function createRedirect($path, $target, $status)
     {
-        // Make sure path begins with a slash.
+        // Make sure path is lower-case & begins with a slash.
         if ($path[0] !== '/') {
-            $path = '/'.$path;
+            $path = strtolower('/'.$path);
         }
 
         // Create or update a record in the redirects dictionary.

--- a/app/Services/Fastly.php
+++ b/app/Services/Fastly.php
@@ -76,12 +76,12 @@ class Fastly extends RestApiClient
         }
 
         // Create or update a record in the redirects dictionary.
-        $redirect = $this->put('dictionary/'.$this->redirects.'/item/'.$path, [
+        $redirect = $this->put('dictionary/'.$this->redirects.'/item/'.urlencode($path), [
             'item_value' => $target,
         ]);
 
         // Create or update a record in the statuses dictionary.
-        $type = $this->put('dictionary/'.$this->types.'/item/'.$path, [
+        $type = $this->put('dictionary/'.$this->types.'/item/'.urlencode($path), [
             'item_value' => $status,
         ]);
 


### PR DESCRIPTION
This pull request adds `fastly:export` and `fastly:import` commands which allow us to clone dictionaries between Fastly properties (most importantly, from our current production property to the new Terraform-managed one) but also could be used to create backups of this data!

I've also fixed a few bugs with the admin flow:
 - Trying to create a redirect that already exists will now overwrite the existing one rather than 500ing.
 - Redirects can no longer contain query strings (because that's not supported in our new simplified VCL) and are automatically converted to lowercase (since all redirects are case-insensitive now).