### PR TITLE
Add email subscription status and topics

### DIFF
--- a/resources/views/users/partials/profile.blade.php
+++ b/resources/views/users/partials/profile.blade.php
@@ -12,8 +12,7 @@
     <dt>Address:</dt><dd>&mdash;</dd>
 @endif
 
-<dt>SMS Status:</dt><dd>{{ $user->sms_status or '&mdash;' }}</dd>
-<dt>SMS Paused:</dt><dd>{{ $user->sms_paused ? '✔' : '✘' }}</dd>
 <dt>Country:</dt><dd>{{ $user->country or '&mdash;' }}</dd>
 <dt>Role:</dt><dd>{{ $user->role or '&mdash;' }}</dd>
 <dt>Voter Registration Status:</dt><dd>{{ $user->voter_registration_status or '&mdash;' }}</dd>
+

--- a/resources/views/users/partials/subscriptions.blade.php
+++ b/resources/views/users/partials/subscriptions.blade.php
@@ -1,0 +1,4 @@
+<dt>SMS Status:</dt><dd>{{ $user->sms_status or '&mdash;' }}</dd>
+<dt>SMS Paused:</dt><dd>{{ $user->sms_paused ? '✔' : '✘' }}</dd>
+<dt>Email Subscription Status:</dt><dd>{{ $user->email_subscription_status ? '✔' : '✘' }}</dd>
+<dt>Email Subscription Topics:</dt><dd>{{ $user->email_subscription_topics ? implode(",  ",$user->email_subscription_topics) : '&mdash;'}}</dd>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -11,8 +11,15 @@
                 @include('layout.errors')
             </div>
             <div class="container__block -half profile-settings">
-                <h3>Profile</h3>
-                @include('users.partials.profile')
+                <div class="container -padded">
+                    <h3>Profile</h3>
+                    @include('users.partials.profile')
+                </div>
+                <div class="container -padded">
+                    <h3>Subscriptions</h3>
+                    @include('users.partials.subscriptions')
+                </div>
+
             </div>
 
             <div class="container__block -half">


### PR DESCRIPTION
### What's Changed

Added `email_subscription_status` and `email_subscription_topics` to user profile. I separated subscriptions out into a separate sections because I thought the list was getting a little long and hard to parse, but as you know I am _not_ a designer so happy to leave everything in one list if folks like that better!

User with no email topics:
![image](https://user-images.githubusercontent.com/4240292/53434362-49b06a80-39ab-11e9-882c-2e2036805adb.png)

User with email topics:
![image](https://user-images.githubusercontent.com/4240292/53434391-592fb380-39ab-11e9-8cbf-43afb4389c2c.png)
