### PR TITLE
Adds email_subscription_status

### DIFF
--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -68,6 +68,15 @@
                       ], null, ['placeholder' => '--']) !!}
                   </div>
           </div>
+          <div class="form-item -padded">
+              {!! Form::label('email_subscription_status', 'Email Subscription Status', ['class' => 'field-label']) !!}
+                  <div class="select">
+                      {!! Form::select('email_subscription_status', [
+                          true => 'Subscribed',
+                          false => 'Unsubscribed',
+                      ], null, ['placeholder' => '--']) !!}
+                  </div>
+          </div>
           @if (auth()->user()->hasRole('admin'))
               <div class="form-item -padded">
                   {!! Form::label('role', 'Role', ['class' => 'field-label']) !!}


### PR DESCRIPTION
Exposes `email_subscription_status` to make testing Customer.io sync easier (refs https://github.com/DoSomething/northstar/pull/846)