### PR TITLE
Password Reset form

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -146,7 +146,7 @@ class UsersController extends Controller
     {
         $type = $request['type'];
 
-        $response = $this->northstar->sendUserPasswordReset($user->id, $type);
+        $this->northstar->sendUserPasswordReset($user->id, $type);
 
         return redirect()->route('users.show', $user->id)->with('flash_message', ['class' => 'messages', 'text' => 'Sent a '.$type.' email to '.$user->email.'.']);
     }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -134,4 +134,20 @@ class UsersController extends Controller
 
         return view('users.search', compact('users', 'query'));
     }
+
+    /**
+     * Sends a reset request to NorthstarAPI to send user a password reset email.
+     *
+     * @param NorthstarUser $user
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function sendPasswordReset(NorthstarUser $user, Request $request)
+    {
+        $type = $request['type'];
+
+        $response = $this->northstar->sendUserPasswordReset($user->id, $type);
+
+        return redirect()->route('users.show', $user->id)->with('flash_message', ['class' => 'messages', 'text' => 'Sent a '.$type.' email to '.$user->email.'.']);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,10 @@
     "type": "project",
     "require": {
         "php": "~7.2.0",
+        "ext-intl": "*",
         "dfurnes/environmentalist": "0.0.1",
         "doctrine/dbal": "^2.5",
-        "dosomething/gateway": "^1.13.1",
-        "ext-intl": "*",
+        "dosomething/gateway": "^1.17",
         "erusev/parsedown": "^1.6",
         "fideloper/proxy": "^3.3",
         "guzzlehttp/guzzle": "^6.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a3283a610b102f5d3904fdc5ee90304",
+    "content-hash": "1a48c15b713e59035fb8aacaff529eeb",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -508,16 +508,16 @@
         },
         {
             "name": "dosomething/gateway",
-            "version": "v1.14.9",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "15d3201b904d34d4220193938c0d4dce067f32dc"
+                "reference": "5a50114aadb40d00bc57885a66ec136091d85833"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/15d3201b904d34d4220193938c0d4dce067f32dc",
-                "reference": "15d3201b904d34d4220193938c0d4dce067f32dc",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/5a50114aadb40d00bc57885a66ec136091d85833",
+                "reference": "5a50114aadb40d00bc57885a66ec136091d85833",
                 "shasum": ""
             },
             "require": {
@@ -565,7 +565,7 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2018-05-30T16:15:17+00:00"
+            "time": "2019-03-13T16:42:17+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -5514,6 +5514,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2018-08-09T05:50:03+00:00"
         },
         {

--- a/resources/views/users/partials/resets.blade.php
+++ b/resources/views/users/partials/resets.blade.php
@@ -1,0 +1,16 @@
+{!! Form::open(['route' => ['users.resets.create', $user->id], 'method' => 'POST']) !!}
+<div class="form-item">
+    {!! Form::label('id', 'Password Resets', ['class' => 'field-label']) !!}
+    <p class="footnote">Send a password reset email to the user.</p>
+</div>
+<div class="form-item -padded">
+    <div class="select">
+        {!! Form::select('type', [
+                'forgot-password' => 'Forgot Password',
+                'rock-the-vote-activate-account' => 'Rock The Vote Activate Account',
+            ], null, ['placeholder' => '-- Select type -- ']) !!}
+    </div>
+</div>
+<div class="form-actions">
+    {!! Form::submit('Send email', ['class' => 'button -secondary']) !!}
+</div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -19,7 +19,6 @@
                     <h3>Subscriptions</h3>
                     @include('users.partials.subscriptions')
                 </div>
-
             </div>
 
             <div class="container__block -half">
@@ -27,6 +26,9 @@
                     @if(Auth::user()->hasRole('admin'))
                         <div class="danger-zone">
                             <h4 class="danger-zone__heading">Danger Zone&#8482;</h4>
+                            <div class="danger-zone__block">
+                                @include('users.partials.resets')
+                            </div>
                             <div class="danger-zone__block">
                                 {!! Form::open(['route' => ['users.merge.create', $user->id], 'method' => 'GET']) !!}
                                 <div class="form-item">

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ $router->resource('users', 'UsersController', ['except' => ['create', 'store']])
 $router->get('search', ['as' => 'user.search', 'uses' => 'UsersController@search']);
 $router->get('users/{user}/merge', ['as' => 'users.merge.create', 'uses' => 'MergeController@create']);
 $router->post('users/{user}/merge', ['as' => 'users.merge.store', 'uses' => 'MergeController@store']);
+$router->post('users/{user}/resets', ['as' => 'users.resets.create', 'uses' => 'UsersController@sendPasswordReset']);
 
 // Superusers
 $router->resource('superusers', 'SuperusersController', ['only' => ['index']]);


### PR DESCRIPTION
Adds a new Danger Zone ™️ form for executing `POST /v/2/resets` requests, allowing admins an easy way to test Activate Account emails that'd otherwise be triggered via Chompy imports or Postman requests. Blocked by https://github.com/DoSomething/gateway/pull/122

<img width="1067" alt="Screen Shot 2019-03-12 at 12 03 16 PM" src="https://user-images.githubusercontent.com/1236811/54228368-4515a700-44bf-11e9-9e91-e1379a7b34fb.png">
