### PR TITLE
Updates external profile links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,6 @@ FASTLY_API_KEY=
 FASTLY_TABLE_REDIRECTS=
 FASTLY_TABLE_REDIRECT_TYPES=
 
-DRUPAL_URL=https://dev.dosomething.org:8888
-GLADIATOR_URL=https://gladiator.dev:8000
+CUSTOMER_IO_PROFILE_URL=https://fly.customer.io/env/63547/people
+ROGUE_PROFILE_URL=https://rogue.test/users
+GAMBIT_PROFILE_URL=https://gambit-admin-staging.herokuapp.com/users

--- a/config/services.php
+++ b/config/services.php
@@ -25,12 +25,16 @@ return [
         ],
     ],
 
-    'drupal' => [
-        'url' => env('DRUPAL_URL'),
+    'customerio' => [
+        'profile_url' => env('CUSTOMER_IO_PROFILE_URL', 'https://fly.customer.io/env/63704/people'),
     ],
 
-    'gladiator' => [
-        'url' => env('GLADIATOR_URL', 'https://gladiator.dosomething.org'),
+    'gambit' => [
+        'profile_url' => env('GAMBIT_PROFILE_URL', 'https://gambit-admin.herokuapp.org/users'),
+    ],
+
+    'rogue' => [
+        'profile_url' => env('ROGUE_PROFILE_URL', 'https://activity.dosomething.org/users'),
     ],
 
     'fastly' => [

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -47,20 +47,17 @@
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block -narrow profile-settings">
-                <h3>Connected Accounts</h3>
-                @if(! empty($user->drupal_id))
-                    <dt>Phoenix:</dt><dd><a href="{{ config('services.drupal.url') }}/user/{{ $user->drupal_id }}">{{ $user->drupal_id }}</a></dd>
-                @else
-                    <dt>Phoenix:</dt><dd>&mdash;</dd>
-                @endif
-
-                <dt>Gladiator:</dt><dd><a href="{{ config('services.gladiator.url') }}/users/{{ $user->id }}">{{ $user->id }}</a></dd>
-
-                @if(! empty($user->mobilecommons_id))
-                    <dt>Mobile Commons:</dt><dd><a href="https://secure.mcommons.com/profiles/{{ $user->mobilecommons_id }}">{{ $user->mobilecommons_id }}</a></dd>
-                @else
-                    <dt>Mobile Commons:</dt><dd>&mdash;</dd>
-                @endif
+                <h3>Links</h3>
+                <ul>
+                    <li>
+                        <a href="{{ config('services.customerio.profile_url') }}/{{ $user->id }}">Customer.io</a>
+                    </li>
+                    <li>
+                        <a href="{{ config('services.gambit.profile_url') }}/{{ $user->id }}">Gambit</a>
+                    </li>
+                    <li>
+                        <a href="{{ config('services.rogue.profile_url') }}/{{ $user->id }}">Rogue</a>
+                    </li>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Links to Customer.io, Gambit, and Rogue instead of Ashes, Mobile Commons, and Gladiator (RIP). 

The default config variables for profile URL's are set to the production values, so this will require setting config variables on QA upon merge.

Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/151027088