### PR TITLE
Displays source and source_details as full width

### DIFF
--- a/resources/views/users/partials/profile.blade.php
+++ b/resources/views/users/partials/profile.blade.php
@@ -1,3 +1,4 @@
+<dt>ID:</dt><dd>{{ $user->id }}</dd>
 <dt>Email:</dt><dd>{{ $user->email or '&mdash;' }}</dd>
 <dt>Mobile:</dt><dd>{{ $user->prettyMobile('&mdash;') }}</dd>
 <dt>First Name:</dt><dd>{{ $user->first_name or '&mdash;' }}</dd>

--- a/resources/views/users/partials/profile.blade.php
+++ b/resources/views/users/partials/profile.blade.php
@@ -1,11 +1,8 @@
-<dt>ID:</dt><dd>{{ $user->id }}</dd>
 <dt>Email:</dt><dd>{{ $user->email or '&mdash;' }}</dd>
 <dt>Mobile:</dt><dd>{{ $user->prettyMobile('&mdash;') }}</dd>
 <dt>First Name:</dt><dd>{{ $user->first_name or '&mdash;' }}</dd>
 <dt>Last Name:</dt><dd>{{ $user->last_name or '&mdash;' }}</dd>
 <dt>Birthdate:</dt><dd>{{ $user->birthdate or '&mdash;' }}</dd>
-<dt>Source:</dt><dd>{{ $user->source or '&mdash;' }}</dd>
-<dt>Source Detail:</dt><dd>{{ $user->source_detail or '&mdash;' }}</dd>
 
 @if (isset($user->addr_street1) || isset($user->addr_street2) || isset($user->addr_city) || isset($user->addr_state) || isset($user->addr_zip) )
     <dt>Address:</dt><dd>{{ $user->addr_street1 or '' }} {{ $user->addr_street2 or '' }} {{ $user->addr_city or '' }} {{ $user->addr_state or '' }} {{ $user->addr_zip or '' }}</dd>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -6,9 +6,11 @@
 
     <div class="container">
         <div class="wrapper">
-            <div class="container__block">
+            <div class="container__block profile-settings">
                 <h1>{{ $user->displayName() }}</h1>
                 @include('layout.errors')
+                <dt>Source:</dt><dd>{{ $user->source or '&mdash;' }}</dd>
+                <dt>Source Detail:</dt><dd>{{ $user->source_detail or '&mdash;' }}</dd>
             </div>
             <div class="container__block -half profile-settings">
                 <div class="container -padded">


### PR DESCRIPTION
Follow up from #213 -- this PR moves `source` and `source_details` out of the `-half` class and beneath the User ID heading to expose full values for lengthy `source_details`.

<img width="982" alt="Screen Shot 2019-04-02 at 4 36 27 PM" src="https://user-images.githubusercontent.com/1236811/55442968-af24e780-5565-11e9-8ebb-fd4ece7a312f.png">

