### PR TITLE
Add Voter Registration Status field to Profile Edit Form

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -74,11 +74,6 @@ class UsersController extends Controller
     {
         $input = $request->except('_token', '_id', 'drupal_uid');
 
-        // @HACK: This field should be `nullable` in Northstar.
-        if (is_null($input['sms_status'])) {
-            unset($input['sms_status']);
-        }
-
         $input['email_subscription_topics'] = ! empty($input['email_subscription_topics']) ? $input['email_subscription_topics'] : [];
 
         $this->northstar->updateUser($user->id, $input);

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -78,6 +78,18 @@
                   </div>
           </div>
           <div class="form-item -padded">
+              {!! Form::label('voter_registration_status', 'Voter Registration Status', ['class' => 'field-label']) !!}
+                  <div class="select">
+                      {!! Form::select('voter_registration_status', [
+                          'uncertain' => 'Uncertain',
+                          'ineligible' => 'Ineligible',
+                          'unregistered' => 'Unregistered',
+                          'confirmed' => 'Confirmed',
+                          'registration_complete' => 'Registration Complete',
+                      ], null, ['placeholder' => '--']) !!}
+                  </div>
+          </div>
+          <div class="form-item -padded">
               {!! Form::label('email_subscription_topics', 'Email Subscription Topics', ['class' => 'field-label']) !!}
                   <div>
                     {!! Form::checkbox('email_subscription_topics[]', 'community') !!}


### PR DESCRIPTION
## What's this PR do?

This PR adds the `voter_registration_status` field to the User's profile edit form.

https://github.com/DoSomething/aurora/pull/219/commits/d52fcbd472779266312e02ae0fa07c43460510b1 Removes a hack to strip the `sms_status` field from the Northstar payload if `null` since we've made that field `nullable`.

## How should this be reviewed?
👀 

## Any background context you want to provide?
This won't actually completely work until we merge https://github.com/DoSomething/northstar/pull/903 to remove some hierarchy validation for arbitrary status updates and make this field `nullable` within Northstar's [Registerer validation](https://github.com/DoSomething/northstar/pull/903/files#diff-78498fe993d8f7dfd5cff7adddcdad3fR69) to allow submitting this field when it's unset or to actively unset this field.

And @katiecrane sorry to belabor this point, but I just want to confirm that you think it's the correct call to have us send along a `null` value for this field instead of restraining it in Aurora so we don't unset anything in Northstar? (One new thought I had is that it might be indirect to allow what is formally a placeholder value to actually update the database?)

## Relevant Tickets

[Pivotal ID #165974120](https://www.pivotaltracker.com/story/show/165974120)