### PR TITLE
Edit refer-friends feature flag

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -76,8 +76,11 @@ class UsersController extends Controller
 
         $input['email_subscription_topics'] = ! empty($input['email_subscription_topics']) ? $input['email_subscription_topics'] : [];
 
-        if (array_key_exists('feature_flags', $input) && in_array('badges', $input['feature_flags'])) {
-            $input['feature_flags'] = ['badges' => true];
+        if (array_key_exists('feature_flags', $input)) {
+            $input['feature_flags'] = [
+                'badges' => in_array('badges', $input['feature_flags']),
+                'refer-friends' => in_array('refer-friends', $input['feature_flags']),
+            ];
         } else {
             unset($input['feature_flags']);
         }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -112,8 +112,12 @@
             <div class="form-item -padded">
               {!! Form::label('feature_flags', 'Feature Flags', ['class' => 'field-label']) !!}
                   <div>
-                    {!! Form::checkbox('feature_flags[]', 'badges', $user->feature_flags['badges'], $user->feature_flags['badges'] ? ['disabled' => true] : null) !!}
+                    {!! Form::checkbox('feature_flags[]', 'badges', $user->feature_flags['badges']) !!}
                     {!! Form::label('badges', 'badges') !!}
+                  </div>
+                  <div>
+                    {!! Form::checkbox('feature_flags[]', 'refer-friends', $user->feature_flags['refer-friends']) !!}
+                    {!! Form::label('refer-friends', 'refer-friends') !!}
                   </div>
           </div>
           @if (auth()->user()->hasRole('admin'))


### PR DESCRIPTION
This PR adds support to edit the `refer-friends` feature flag value introduced in https://github.com/DoSomething/northstar/pull/915.

#220 did not let admins remove the `badges` feature flag by disabling the input, but it's pretty tricky to keep this logic for two checkboxes: If a user has the badges flag, the input is disabled. We want to give them the refer-friends feature flag, save, but then the user no longer has the badges flag because the input was disabled. I decided to go for a simpler approach by just making both flags editable. cc @ngjo 