### PR TITLE
Don't break edit user page if a feature_flag isn't set

### DIFF
--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -112,11 +112,11 @@
             <div class="form-item -padded">
               {!! Form::label('feature_flags', 'Feature Flags', ['class' => 'field-label']) !!}
                   <div>
-                    {!! Form::checkbox('feature_flags[]', 'badges', $user->feature_flags['badges']) !!}
+                    {!! Form::checkbox('feature_flags[]', 'badges', data_get($user, 'feature_flags.badges', false)) !!}
                     {!! Form::label('badges', 'badges') !!}
                   </div>
                   <div>
-                    {!! Form::checkbox('feature_flags[]', 'refer-friends', $user->feature_flags['refer-friends']) !!}
+                    {!! Form::checkbox('feature_flags[]', 'refer-friends',  data_get($user, 'feature_flags.refer-friends', false))!!}
                     {!! Form::label('refer-friends', 'refer-friends') !!}
                   </div>
           </div>


### PR DESCRIPTION
The edit user page was breaking if one `feature_flags` value is set but not the other. Things were fine if the user had no `feature_flags` or had both `feature_flags` (here being `badges` and `refer-friends`).

 @mendelB found [this tidbit](https://stackoverflow.com/questions/20009076/php-undefined-index-notice-not-raised-when-indexing-null-variable/20081922#20081922) to explain that behavior:
```
PHP won't attempt the comparison if the array is null.

In the second circumstance, a comparison does occur because the array is set. PHP does not check to see if it is empty.
```
and he also suggested using `data_get` to make sure we aren't trying to access `null` elements. I've made that update here!