### PR TITLE
Properly fetch optional fields for 'edit' form.

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -57,11 +57,14 @@ class UsersController extends Controller
     /**
      * Display the form for editing user information
      *
-     * @param NorthstarUser $user
+     * @param string $id
      * @return \Illuminate\Http\Response
      */
-    public function edit(NorthstarUser $user)
+    public function edit($id)
     {
+        $optionalFields = ['last_name', 'email', 'mobile', 'birthdate', 'addr_street1', 'addr_street2'];
+        $user = gateway('northstar')->getUser($id, $optionalFields);
+
         return view('users.edit', ['user' => $user, 'title' => $user->display_name]);
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,8 @@ $router->get('auth/login', 'Auth\AuthController@getLogin');
 $router->get('auth/logout', 'Auth\AuthController@getLogout');
 
 // Users
-$router->resource('users', 'UsersController', ['except' => ['create', 'store']]);
+$router->resource('users', 'UsersController', ['except' => ['create', 'edit', 'store']]);
+$router->get('users/{id}/edit', ['as' => 'users.edit', 'uses' => 'UsersController@edit']);
 $router->get('search', ['as' => 'user.search', 'uses' => 'UsersController@search']);
 $router->get('users/{user}/merge', ['as' => 'users.merge.create', 'uses' => 'MergeController@create']);
 $router->post('users/{user}/merge', ['as' => 'users.merge.store', 'uses' => 'MergeController@store']);


### PR DESCRIPTION
This pull request includes a "quick fix" to the `users/{id}/edit` page, which was [not loading optional fields & so those fields would appear blank](https://dosomething.slack.com/archives/C02BBRN5A/p1570559704003600). Longer term, I'd like to spend a bit of time to get this working similarly to the "show" page (with 👁's), but this gets things back in working order!

References [#169023024](https://www.pivotaltracker.com/story/show/169023024)