### PR TITLE
Remove ability to choose redirect HTTP status.

### DIFF
--- a/app/Http/Controllers/RedirectsController.php
+++ b/app/Http/Controllers/RedirectsController.php
@@ -76,12 +76,11 @@ class RedirectsController extends Controller
         $this->validate($request, [
             'path' => 'required|string|regex:/^[^?]+$/',
             'target' => 'required|url',
-            'status' => 'required|in:301,302',
         ], [
             'path.regex' => 'Paths cannot contain query strings.',
         ]);
 
-        $redirect = $this->fastly->createRedirect($request->path, $request->target, $request->status);
+        $redirect = $this->fastly->createRedirect($request->path, $request->target);
 
         return redirect()->route('redirects.show', $redirect->id);
     }
@@ -110,10 +109,9 @@ class RedirectsController extends Controller
     {
         $this->validate($request, [
             'target' => 'required|url',
-            'status' => 'required|in:301,302',
         ]);
 
-        $this->fastly->updateRedirect($redirect->path, $request->target, $request->status);
+        $this->fastly->updateRedirect($redirect->path, $request->target);
 
         return redirect()->route('redirects.show', $redirect->id);
     }

--- a/app/Resources/Redirect.php
+++ b/app/Resources/Redirect.php
@@ -22,9 +22,8 @@ class Redirect extends ApiResponse implements JsonSerializable
     }
 
     /**
-     * Create a new redirect from the corresponding Fastly
-     * dictionary items (redirect & status key/value pairs).
-     * @param $attributes
+     * Create a new redirect from the Fastly dictionary item.
+     * @param $redirect
      */
     public static function fromItems($redirect)
     {

--- a/app/Resources/Redirect.php
+++ b/app/Resources/Redirect.php
@@ -26,13 +26,12 @@ class Redirect extends ApiResponse implements JsonSerializable
      * dictionary items (redirect & status key/value pairs).
      * @param $attributes
      */
-    public static function fromItems($redirect, $type)
+    public static function fromItems($redirect)
     {
         return new static([
             'id' => self::encodeId($redirect),
             'path' => $redirect['item_key'],
             'target' => $redirect['item_value'],
-            'status' => $type['item_value'],
             'updated_at' => array_get($redirect, 'updated_at', Carbon::now()), // not returned from updates.
             'created_at' => array_get($redirect, 'updated_at', Carbon::now()), // not returned from updates.
         ]);

--- a/config/services.php
+++ b/config/services.php
@@ -43,6 +43,5 @@ return [
         'service_url' => env('FASTLY_SERVICE_URL'),
         'api_key' => env('FASTLY_API_KEY'),
         'redirects_table' => env('FASTLY_TABLE_REDIRECTS'),
-        'types_table' => env('FASTLY_TABLE_REDIRECT_TYPES'),
     ],
 ];

--- a/resources/views/redirects/create.blade.php
+++ b/resources/views/redirects/create.blade.php
@@ -24,16 +24,6 @@
                         'placeholder' => 'e.g. https://www.dosomething.org/new-path']) !!}
                     </div>
 
-                    <div class="form-item -padded">
-                        {!! Form::label('status', 'Redirect Type', ['class' => 'field-label']) !!}
-                        <div class="select">
-                            {!! Form::select('status', ['301' => '301 (Moved Permanently)', '302' => '302 (Found)']) !!}
-                        </div>
-                        <em class="footnote">With <strong>301 Moved Permanently</strong>,
-                            Google will update their records with this new URL. Use
-                            <strong>302 Found</strong> if the redirect is temporary.</em>
-                    </div>
-
                     {!! Form::submit('Submit', ['class' => 'button']) !!}
                 {!! Form::close() !!}
             </div>

--- a/resources/views/redirects/edit.blade.php
+++ b/resources/views/redirects/edit.blade.php
@@ -26,15 +26,6 @@
                         'placeholder' => 'e.g. https://www.dosomething.org/new-path']) !!}
                     </div>
 
-                    <div class="form-item -padded">
-                        {!! Form::label('status', 'Redirect Type', ['class' => 'field-label']) !!}
-                        <div class="select">
-                            {!! Form::select('status', ['301' => '301 (Moved Permanently)', '302' => '302 (Found)'], $redirect->status) !!}
-                        </div>
-                        <em class="footnote">With <strong>301 Moved Permanently</strong>,
-                            Google will update their records with this new URL. Use
-                            <strong>302 Found</strong> if the redirect is temporary.</em>
-                    </div>
                     {!! Form::submit('Submit', ['class' => 'button']) !!}
                 </form>
 

--- a/resources/views/redirects/index.blade.php
+++ b/resources/views/redirects/index.blade.php
@@ -20,15 +20,13 @@
                       <tr class="row table-header">
                           <th class="table-cell">Path</th>
                           <th class="table-cell">Target</th>
-                          <th class="table-cell">Status</th>
                       </tr>
                   </thead>
                   <tbody>
                       @foreach($redirects as $redirect)
                           <tr class="table-row">
                               <td class="table-cell break-all" title="{{ $redirect->path }}"><a href="{{ route('redirects.show', [$redirect->id]) }}">{{ str_limit($redirect->path, 40) }}</a></td>
-                              <td class="table-cell break-all" title="{{ $redirect->target }}">{{ str_limit($redirect->target, 40) }}</td>
-                              <td class="table-cell"><code>{{ $redirect->status }}</code></td>
+                              <td class="table-cell break-all" title="{{ $redirect->target }}">{{ str_limit($redirect->target, 60) }}</td>
                           </tr>
                       @endforeach
                   </tbody>

--- a/resources/views/redirects/show.blade.php
+++ b/resources/views/redirects/show.blade.php
@@ -16,7 +16,7 @@
                 <label class="field-label">Target:</label>
                 <code class="break-all">{{ $redirect->target }}</code><br><br>
                 <label class="field-label">Redirect Status:</label>
-                <code>{{ $redirect->status == '301' ? '301 (Moved Permanently)' : '302 (Found)'}}</code><br><br>
+                <code>302 (Found)</code><br><br>
             </div>
 
             <div class="container__block -half">


### PR DESCRIPTION
This pull request (alongside DoSomething/infrastructure#211) removes the ability to set `301 Moved Permanently` redirects in Aurora since they're, well, permanent(!) and that's a lot of power to wield without a peer-review process.

This should be deployed after DoSomething/infrastructure#211. References [#168057201](https://www.pivotaltracker.com/story/show/168057201).