### PR TITLE
Allow staff/admins to delete user accounts.

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -104,8 +104,9 @@ class UsersController extends Controller
      */
     public function destroy(NorthstarUser $user)
     {
-        // @TODO!
-        return redirect()->back()->with('flash_message', ['class' => 'messages', 'text' => 'Not yet implemented.']);
+        $this->northstar->deleteUser($user->id);
+
+        return redirect()->route('users.index')->with('flash_message', ['class' => 'messages', 'text' => 'User deleted.']);
     }
 
     /**

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -10,7 +10,7 @@
                 <p>Welcome to the <strong>DoSomething.org admin interface</strong>. If you're looking to
                 manage user accounts or domain redirects, you're in the right place.</p>
 
-                <p>Drop a message in the <code>#help-web-template</code> Slack room if you can't log in!</p>
+                <p>Drop a message in the <code>#help-product</code> Slack room if you can't log in!</p>
 
                 <p><a href="/auth/login" class="button">Log In</a></p>
         </div>

--- a/resources/views/search/search.blade.php
+++ b/resources/views/search/search.blade.php
@@ -1,6 +1,6 @@
 {!! Form::open(['action' => 'UsersController@search', 'method' => 'GET']) !!}
 <div class="form-actions -inline">
-    <li>{!! Form::text('query', request()->get('query'), ['class' => 'text-field -search', 'placeholder' => 'Search by email, mobile, Drupal ID…', 'style' => 'min-width: 400px']) !!}</li>
+    <li>{!! Form::text('query', request()->get('query'), ['class' => 'text-field -search', 'placeholder' => 'Find user by email, mobile, ID…', 'style' => 'min-width: 400px']) !!}</li>
     <li>{!! Form::submit('Search', ['class' => 'button']) !!}</li>
 </div>
 {!! Form::close () !!}

--- a/resources/views/users/partials/danger-zone.blade.php
+++ b/resources/views/users/partials/danger-zone.blade.php
@@ -21,11 +21,10 @@
         {!! Form::open(['route' => ['users.destroy', $user->id], 'method' => 'DELETE']) !!}
         <div class="form-item">
             <label for="role" class="field-label">Delete Account</label>
-            <p class="footnote">This will <strong>permanently remove</strong> a user's account from Northstar.
-                This is the point of no return! Beware!</p>
+            <p class="footnote">This will <strong>permanently destroy</strong> this user's Northstar & Customer.io profiles, Rogue campaign activity, and Gambit conversation history.</p>
         </div>
         <div class="form-actions">
-            {{ Form::submit('Delete Now', [
+            {{ Form::submit('Delete Immediately', [
                 'class' => 'button -secondary -danger',
                 'data-confirm' => 'Are you sure you want to immediately & permanently destroy this user? THIS CANNOT BE UNDONE.'
             ]) }}

--- a/resources/views/users/partials/danger-zone.blade.php
+++ b/resources/views/users/partials/danger-zone.blade.php
@@ -26,7 +26,7 @@
         <div class="form-actions">
             {{ Form::submit('Delete Immediately', [
                 'class' => 'button -secondary -danger',
-                'data-confirm' => 'Are you sure you want to immediately & permanently destroy this user? THIS CANNOT BE UNDONE.'
+                'data-confirm' => 'Are you sure you want to immediately & permanently destroy all of '.$user->display_name.'\'s data? THIS CANNOT BE UNDONE.'
             ]) }}
         </div>
         {!! Form::close() !!}

--- a/resources/views/users/partials/danger-zone.blade.php
+++ b/resources/views/users/partials/danger-zone.blade.php
@@ -25,7 +25,10 @@
                 This is the point of no return! Beware!</p>
         </div>
         <div class="form-actions">
-            {!! Form::submit('Delete User', ['class' => 'button -secondary -danger']) !!}
+            {{ Form::submit('Delete Now', [
+                'class' => 'button -secondary -danger',
+                'data-confirm' => 'Are you sure you want to immediately & permanently destroy this user? THIS CANNOT BE UNDONE.'
+            ]) }}
         </div>
         {!! Form::close() !!}
     </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -6,6 +6,15 @@
 
     <div class="container">
         <div class="wrapper">
+            @if ($user->deletion_requested_at)
+                <div class="container__block">
+                    <div class="danger-zone">
+                        <strong>This user requested to delete their account on {{ (new Carbon\Carbon($user->deletion_requested_at))->format('F d, Y')}}.</strong>
+                        We automatically process account deletions two weeks after the request is made. Users can "undo" this request from their account page.
+                    </div>
+                </div>
+            @endif
+
             <div class="container__block profile-settings">
                 <h1>{{ $user->display_name }}</h1>
                 @include('layout.errors')


### PR DESCRIPTION
### What's this PR do?

This pull request hooks up the "Delete Account" interface in Aurora to Northstar's new super-charged `DELETE v2/users/{id}` endpoint. This allows admins to delete a user from Northstar, Rogue, Gambit, and Customer.io on demand:

![Screen Shot 2020-02-25 at 1 20 50 PM](https://user-images.githubusercontent.com/583202/75274919-a79bac00-57d1-11ea-80d9-a19aa80c0ac0.png)

Aurora will also now display a banner if an account has been queued for deletion:

![Screen Shot 2020-02-25 at 1 21 28 PM](https://user-images.githubusercontent.com/583202/75274972-beda9980-57d1-11ea-8394-6828aaec114b.png)

I've also fixed up the homepage copy to direct users to `#help-product` if they need permissions.

### How should this be reviewed?

👀

### Any background context you want to provide?

I decided to hold off on allowing admins to queue/de-queue accounts for deletion, since I think if a user requests their account to be deleted we should be very careful about "undo-ing" that change.

### Relevant tickets

References [Pivotal #170953777](https://www.pivotaltracker.com/story/show/170953777).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
