### PR TITLE
Adds user sms_subscription_topics

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -80,6 +80,7 @@ class UsersController extends Controller
         $input = $request->except('_token', '_id', 'drupal_uid');
 
         $input['email_subscription_topics'] = ! empty($input['email_subscription_topics']) ? $input['email_subscription_topics'] : [];
+        $input['sms_subscription_topics'] = ! empty($input['sms_subscription_topics']) ? $input['sms_subscription_topics'] : [];
 
         if (array_key_exists('feature_flags', $input)) {
             $input['feature_flags'] = [

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -69,6 +69,13 @@
                   </div>
           </div>
           <div class="form-item -padded">
+              {!! Form::label('sms_subscription_topics', 'SMS Subscription Topics', ['class' => 'field-label']) !!}
+                  <div>
+                    {!! Form::checkbox('sms_subscription_topics[]', 'voting') !!}
+                    {!! Form::label('voting', 'voting') !!}
+                  </div>
+          </div>
+          <div class="form-item -padded">
               {!! Form::label('email_subscription_status', 'Email Subscription Status', ['class' => 'field-label']) !!}
                   <div class="select">
                       {!! Form::select('email_subscription_status', [

--- a/resources/views/users/partials/subscriptions.blade.php
+++ b/resources/views/users/partials/subscriptions.blade.php
@@ -1,4 +1,5 @@
 <dt>SMS Status:</dt><dd>{{ $user->sms_status or '&mdash;' }}</dd>
 <dt>SMS Paused:</dt><dd>{{ $user->sms_paused ? '✔' : '✘' }}</dd>
+<dt>SMS Subscription Topics:</dt><dd>{{ $user->sms_subscription_topics ? implode(",  ",$user->sms_subscription_topics) : '&mdash;'}}</dd>
 <dt>Email Subscription Status:</dt><dd>{{ $user->email_subscription_status ? '✔' : '✘' }}</dd>
 <dt>Email Subscription Topics:</dt><dd>{{ $user->email_subscription_topics ? implode(",  ",$user->email_subscription_topics) : '&mdash;'}}</dd>


### PR DESCRIPTION
### What's this PR do?

This pull request adds the new `sms_subscription_topics` introduced in https://github.com/DoSomething/northstar/pull/998 as a viewable/editable field on a User.

### How should this be reviewed?

👀 

<img width="390" alt="Screen Shot 2020-03-19 at 3 36 19 PM" src="https://user-images.githubusercontent.com/1236811/77121099-aa1bab00-69f7-11ea-9c3b-2e2441b7b033.png">
### Any background context you want to provide?

✂️ 📑 

### Relevant tickets

References [Pivotal #https://www.pivotaltracker.com/n/projects/2417735/stories/171847123](https://www.pivotaltracker.com/n/projects/2417735/stories/c).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
