### PR TITLE
Display referrer on user view

### DIFF
--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -51,7 +51,8 @@
                 @endif
                 <p class="footnote">
                     Last updated: {{ $user->updated_at->format('F d, Y g:ia') }}<br />
-                    Created: {{ $user->created_at->format('F d, Y g:ia') }} ({{ $user->created_at->diffForHumans() }})
+                    Created: {{ $user->created_at->format('F d, Y g:ia') }} ({{ $user->created_at->diffForHumans() }})<br />
+                    Referrer: {{ $user->referrer_user_id ? $user->referrer_user_id : '-' }}
                 </p>
             </div>
         </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -47,12 +47,17 @@
         <div class="wrapper">
             <div class="container__block -half">
                 @if(Auth::user()->hasRole('admin'))
-                    <a class="secondary" href="{{ url('users/' . $user->id . '/edit') }}">Update user's profile</a>
+                    <a class="primary" href="{{ url('users/' . $user->id . '/edit') }}">Update user's profile</a>
                 @endif
                 <p class="footnote">
                     Last updated: {{ $user->updated_at->format('F d, Y g:ia') }}<br />
                     Created: {{ $user->created_at->format('F d, Y g:ia') }} ({{ $user->created_at->diffForHumans() }})<br />
-                    Referrer: {{ $user->referrer_user_id ? $user->referrer_user_id : '-' }}
+                    Referrer: 
+                    @if ($user->referrer_user_id)
+                      <a href="{{ url('users/' . $user->referrer_user_id) }}">{{$user->referrer_user_id}}</a>
+                    @else
+                      -
+                    @endif
                 </p>
             </div>
         </div>


### PR DESCRIPTION
### What's this PR do?

This pull request displays the `referrer_user_id` field on a user (added in https://github.com/DoSomething/northstar/pull/1000) if it exists.

Because it links to the referrer, I've made the link to update the user a primary one to stand out.

<img width="420" alt="Screen Shot 2020-03-26 at 9 36 24 AM" src="https://user-images.githubusercontent.com/1236811/77671846-65d36200-6f45-11ea-8a9b-646104fed02d.png">


### How should this be reviewed?

👀 

### Any background context you want to provide?

🔗 

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/story/show/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
