### PR TITLE
Makes sms subscription topics read-only

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -81,7 +81,6 @@ class UsersController extends Controller
 
         $input['causes'] = ! empty($input['causes']) ? $input['causes'] : [];
         $input['email_subscription_topics'] = ! empty($input['email_subscription_topics']) ? $input['email_subscription_topics'] : [];
-        $input['sms_subscription_topics'] = ! empty($input['sms_subscription_topics']) ? $input['sms_subscription_topics'] : [];
 
         if (array_key_exists('feature_flags', $input)) {
             $input['feature_flags'] = [

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -69,17 +69,6 @@
                   </div>
           </div>
           <div class="form-item -padded">
-              {!! Form::label('sms_subscription_topics', 'SMS Subscription Topics', ['class' => 'field-label']) !!}
-                  <div>
-                    {!! Form::checkbox('sms_subscription_topics[]', 'general') !!}
-                    {!! Form::label('general', 'general') !!}
-                  </div>
-                  <div>
-                    {!! Form::checkbox('sms_subscription_topics[]', 'voting') !!}
-                    {!! Form::label('voting', 'voting') !!}
-                  </div>
-          </div>
-          <div class="form-item -padded">
               {!! Form::label('email_subscription_status', 'Email Subscription Status', ['class' => 'field-label']) !!}
                   <div class="select">
                       {!! Form::select('email_subscription_status', [


### PR DESCRIPTION
### What's this PR do?

This pull request removes the `sms_subscription_topics` from the user edit form. It was interfering with setting default topics if changing from unsubscribed to subscribed, even with the check in the `UserController`. This at least unblocks merging https://github.com/DoSomething/northstar/pull/1008.

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

This was a rabbit hole :rabbit: 

### Relevant tickets

References [Pivotal #2417735](https://www.pivotaltracker.com/n/projects/2417735).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
