### PR TITLE
Updating deprecated method and some cleanup.

### DIFF
--- a/app/Http/Middleware/ForceHttps.php
+++ b/app/Http/Middleware/ForceHttps.php
@@ -3,8 +3,9 @@
 namespace Aurora\Http\Middleware;
 
 use Closure;
-use League\Uri\Schemes\Http;
+use League\Uri\Http;
 use function League\Uri\parse;
+use Illuminate\Support\Facades\Log;
 
 class ForceHttps
 {
@@ -17,9 +18,11 @@ class ForceHttps
      */
     public function handle($request, Closure $next)
     {
-        // If running in a production environment, redirect all traffic to HTTPS
+        // If running in a non-local environment, redirect all traffic to HTTPS
         // and the correct canonical URL, e.g. never '*.herokuapp.com'!
-        if (config('app.env') == 'production') {
+        if (config('app.env') !== 'local') {
+            Log::debug($request);
+
             $canonicalHost = parse(config('app.url'))['host'];
             $hasIncorrectHost = $request->header('Host') !== $canonicalHost;
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `ForceHttps.php` middleware to remove the deprecated `League\Uri\Schemes\Http` class and use `League\Uri\Http` instead. 

After the recent [Laravel upgrade to 5.6](https://github.com/DoSomething/aurora/pull/248), our Aurora Dev & QA instances have been borked and running into a redirect loop of sorts. We suspect it's due to the upgrades leading to the full deprecation of the above class and associated method we utilized. Updating to the new class should solve the issue. 🤞 

Also does a little cleanup to ensure it applies the middleware to all non-local instances, and adds a debug logging statement for help in future troubleshooting.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #172383668](https://www.pivotaltracker.com/story/show/172383668).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
