### PR TITLE
Forcehttps middleware logging update

### DIFF
--- a/app/Http/Middleware/ForceHttps.php
+++ b/app/Http/Middleware/ForceHttps.php
@@ -21,10 +21,14 @@ class ForceHttps
         // If running in a non-local environment, redirect all traffic to HTTPS
         // and the correct canonical URL, e.g. never '*.herokuapp.com'!
         if (config('app.env') !== 'local') {
-            Log::debug('Middelware/ForceHttps@handle Request:', $request);
-
             $canonicalHost = parse(config('app.url'))['host'];
             $hasIncorrectHost = $request->header('Host') !== $canonicalHost;
+
+            Log::debug('Middelware/ForceHttps@handle Request:', [
+                'Canonical Host' => $canonicalHost,
+                'Incorrect Request Host' => $hasIncorrectHost,
+                'Secure Request' => $request->secure(),
+            ]);
 
             if ($hasIncorrectHost || ! $request->secure()) {
                 $parsedUrl = parse($request->url());
@@ -32,6 +36,11 @@ class ForceHttps
                 $parsedUrl['host'] = $canonicalHost;
 
                 $secureUrl = Http::createFromComponents($parsedUrl);
+
+                Log::debug('Middelware/ForceHttps@handle Redirect:', [
+                    'Parsed Request URL' => $parsedUrl,
+                    'Secured URL' => (string) $secureUrl,
+                ]);
 
                 return redirect()->secure((string) $secureUrl);
             }

--- a/app/Http/Middleware/ForceHttps.php
+++ b/app/Http/Middleware/ForceHttps.php
@@ -21,7 +21,7 @@ class ForceHttps
         // If running in a non-local environment, redirect all traffic to HTTPS
         // and the correct canonical URL, e.g. never '*.herokuapp.com'!
         if (config('app.env') !== 'local') {
-            Log::debug($request);
+            Log::debug('Middelware/ForceHttps@handle Request:', $request);
 
             $canonicalHost = parse(config('app.url'))['host'];
             $hasIncorrectHost = $request->header('Host') !== $canonicalHost;

--- a/app/Http/Middleware/ForceHttps.php
+++ b/app/Http/Middleware/ForceHttps.php
@@ -26,6 +26,7 @@ class ForceHttps
 
             Log::debug('Middelware/ForceHttps@handle Request:', [
                 'Canonical Host' => $canonicalHost,
+                'Request Host' => $request->header('Host'),
                 'Incorrect Request Host' => $hasIncorrectHost,
                 'Secure Request' => $request->secure(),
             ]);


### PR DESCRIPTION
### What's this PR do?

This pull request updates the debug logging message to include an initial string label which is required by the method and also helps when perusing the logs in Papertrail 🔍  It also logs more specific information since trying to log the request object would end up with more difficult to visually-read log.

### Relevant tickets

References [Pivotal #172383668](https://www.pivotaltracker.com/story/show/172383668).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
