### PR TITLE
Fixing bug with middleware order.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,11 +15,11 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \Aurora\Http\Middleware\CheckForMaintenanceMode::class,
-        \Aurora\Http\Middleware\ForceHttps::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \Aurora\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \Aurora\Http\Middleware\TrustProxies::class,
+        \Aurora\Http\Middleware\ForceHttps::class,
     ];
 
     /**

--- a/app/Http/Middleware/ForceHttps.php
+++ b/app/Http/Middleware/ForceHttps.php
@@ -11,6 +11,7 @@ class ForceHttps
 {
     /**
      * Handle an incoming request.
+     * This middleware needs to run after the TrustProxies middleware.
      *
      * @param  \Illuminate\Http\Request $request
      * @param  \Closure $next


### PR DESCRIPTION
### What's this PR do?

This pull request hopefully completes my whirlwind journey to resolve a bug I introduced in #247 when I changed the ordering of the middleware.

In the prior PR, I naively thought it would be best to run the `ForceHttps` earlier on in the middleware process, but as it turns out part of the internal logic for that middleware depends on the `TrustProxies` having been set. Thus, we were having a crazy redirection loop happening. It took a while to figure out what exactly was going on, but I strongly suspect this simple change was the culprit!

I added a comment in the `ForceHttps` middleware to know that it needs to happen after `TrustProxies`.

🙏  this fixes things!

### How should this be reviewed?

👀 

### Any background context you want to provide?

![image](https://user-images.githubusercontent.com/105849/90067398-09d36500-dcbd-11ea-9939-9fe94a20935c.png)


### Relevant tickets

References [Pivotal #172383668](https://www.pivotaltracker.com/story/show/172383668).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
