### PR TITLE
Specifiying php version for prettier

### DIFF
--- a/app/Console/Commands/FastlyImportCommand.php
+++ b/app/Console/Commands/FastlyImportCommand.php
@@ -51,12 +51,12 @@ class FastlyImportCommand extends Command
                         $redirect->target .
                         '" (' .
                         $redirect->status .
-                        ')'
+                        ')',
                 );
                 $fastly->createRedirect(
                     $redirect->path,
                     $redirect->target,
-                    $redirect->status
+                    $redirect->status,
                 );
             }
         }

--- a/app/Console/Commands/SetupCommand.php
+++ b/app/Console/Commands/SetupCommand.php
@@ -42,15 +42,15 @@ class SetupCommand extends Command
             $this->chooseEnvironmentVariable(
                 'NORTHSTAR_URL',
                 'Choose a Northstar environment',
-                $environments
+                $environments,
             );
             $this->setEnvironmentVariable(
                 'NORTHSTAR_CLIENT_ID',
-                'Enter the OAuth Client ID'
+                'Enter the OAuth Client ID',
             );
             $this->setEnvironmentVariable(
                 'NORTHSTAR_CLIENT_SECRET',
-                'Enter the OAuth Client Secret'
+                'Enter the OAuth Client Secret',
             );
         });
 
@@ -58,7 +58,7 @@ class SetupCommand extends Command
 
         $this->runArtisanCommand(
             'gateway:key',
-            'Fetching public key from Northstar'
+            'Fetching public key from Northstar',
         );
 
         $this->runArtisanCommand('migrate', 'Running database migrations');

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -56,7 +56,7 @@ class AuthController extends Controller
         return $this->northstar->authorize(
             $request,
             $response,
-            $this->redirectTo
+            $this->redirectTo,
         );
     }
 

--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -28,12 +28,12 @@ class MergeController extends Controller
         $mergedUser = gateway('northstar')->mergeUsers(
             $user->id,
             $duplicateId,
-            true
+            true,
         );
 
         return view(
             'users.merge.create',
-            compact('user', 'mergedUser', 'duplicateId')
+            compact('user', 'mergedUser', 'duplicateId'),
         );
     }
 
@@ -50,7 +50,7 @@ class MergeController extends Controller
         try {
             $reponse = gateway('northstar')->mergeUsers(
                 $user->id,
-                $request->input('merge_id')
+                $request->input('merge_id'),
             );
         } catch (\Exception $exception) {
             $message = 'Merge Unsuccessful. Error: ' . $exception->getMessage();

--- a/app/Http/Controllers/RedirectsController.php
+++ b/app/Http/Controllers/RedirectsController.php
@@ -81,12 +81,12 @@ class RedirectsController extends Controller
             ],
             [
                 'path.regex' => 'Paths cannot contain query strings.',
-            ]
+            ],
         );
 
         $redirect = $this->fastly->createRedirect(
             $request->path,
-            $request->target
+            $request->target,
         );
 
         return redirect()->route('redirects.show', $redirect->id);

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -105,11 +105,11 @@ class UsersController extends Controller
                 'badges' => in_array('badges', $input['feature_flags']),
                 'refer-friends' => in_array(
                     'refer-friends',
-                    $input['feature_flags']
+                    $input['feature_flags'],
                 ),
                 'refer-friends-scholarship' => in_array(
                     'refer-friends-scholarship',
-                    $input['feature_flags']
+                    $input['feature_flags'],
                 ),
             ];
         } else {

--- a/app/Models/AuroraUser.php
+++ b/app/Models/AuroraUser.php
@@ -56,7 +56,7 @@ class AuroraUser extends Model implements
     {
         return app('\Aurora\Services\Northstar')->getUser(
             'id',
-            $this->northstar_id
+            $this->northstar_id,
         );
     }
 

--- a/app/Services/Fastly.php
+++ b/app/Services/Fastly.php
@@ -55,7 +55,7 @@ class Fastly extends RestApiClient
         $key = Redirect::decodeId($id);
 
         $redirect = $this->get(
-            'dictionary/' . $this->redirects . '/item/' . $key
+            'dictionary/' . $this->redirects . '/item/' . $key,
         );
 
         return Redirect::fromItems($redirect);
@@ -77,7 +77,7 @@ class Fastly extends RestApiClient
             'dictionary/' . $this->redirects . '/item/' . urlencode($path),
             [
                 'item_value' => $target,
-            ]
+            ],
         );
 
         return Redirect::fromItems($redirect);
@@ -95,7 +95,7 @@ class Fastly extends RestApiClient
             'dictionary/' . $this->redirects . '/item/' . urlencode($path),
             [
                 'item_value' => $target,
-            ]
+            ],
         );
 
         return Redirect::fromItems($redirect);
@@ -112,7 +112,7 @@ class Fastly extends RestApiClient
 
         // Delete the corresponding record in the redirects dictionary.
         return $this->delete(
-            'dictionary/' . $this->redirects . '/item/' . $key
+            'dictionary/' . $this->redirects . '/item/' . $key,
         );
     }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -83,7 +83,7 @@ function scriptify($json = [], $store = 'STATE')
             $store .
             ' = ' .
             json_encode($json) .
-            '</script>'
+            '</script>',
     );
 }
 
@@ -118,6 +118,6 @@ function revealer(...$fields)
             e(request()->url() . '?include=' . implode(',', $newFields)) .
             '" class="reveal ' .
             ($isActive ? 'is-active' : '') .
-            '" data-turbolinks-action="replace" data-turbolinks-scroll="false"><span>reveal</span></a>'
+            '" data-turbolinks-action="replace" data-turbolinks-scroll="false"><span>reveal</span></a>',
     );
 }

--- a/config/cache.php
+++ b/config/cache.php
@@ -94,6 +94,6 @@ return [
 
     'prefix' => env(
         'CACHE_PREFIX',
-        Str::slug(env('APP_NAME', 'laravel'), '_') . '_cache'
+        Str::slug(env('APP_NAME', 'laravel'), '_') . '_cache',
     ),
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -123,7 +123,7 @@ return [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
             'prefix' => env(
                 'REDIS_PREFIX',
-                Str::slug(env('APP_NAME', 'laravel'), '_') . '_database_'
+                Str::slug(env('APP_NAME', 'laravel'), '_') . '_database_',
             ),
         ],
 

--- a/config/queue.php
+++ b/config/queue.php
@@ -53,7 +53,7 @@ return [
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'prefix' => env(
                 'AWS_SQS_PREFIX',
-                'https://sqs.us-east-1.amazonaws.com/your-account-id'
+                'https://sqs.us-east-1.amazonaws.com/your-account-id',
             ),
             'queue' => env('AWS_SQS_QUEUE', 'your-queue-name'),
             'region' => env('AWS_SQS_REGION', 'us-east-1'),

--- a/config/services.php
+++ b/config/services.php
@@ -34,21 +34,21 @@ return [
     'customerio' => [
         'profile_url' => env(
             'CUSTOMER_IO_PROFILE_URL',
-            'https://fly.customer.io/env/63704/people'
+            'https://fly.customer.io/env/63704/people',
         ),
     ],
 
     'gambit' => [
         'profile_url' => env(
             'GAMBIT_PROFILE_URL',
-            'https://gambit-admin.herokuapp.org/users'
+            'https://gambit-admin.herokuapp.org/users',
         ),
     ],
 
     'rogue' => [
         'profile_url' => env(
             'ROGUE_PROFILE_URL',
-            'https://activity.dosomething.org/users'
+            'https://activity.dosomething.org/users',
         ),
     ],
 

--- a/config/session.php
+++ b/config/session.php
@@ -125,7 +125,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_') . '_session'
+        Str::slug(env('APP_NAME', 'laravel'), '_') . '_session',
     ),
 
     /*

--- a/config/view.php
+++ b/config/view.php
@@ -27,6 +27,6 @@ return [
 
     'compiled' => env(
         'VIEW_COMPILED_PATH',
-        realpath(storage_path('framework/views'))
+        realpath(storage_path('framework/views')),
     ),
 ];

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "prettier": {
     "singleQuote": true,
+    "phpVersion": "7.3",
     "trailingComma": "all"
   },
   "babel": {


### PR DESCRIPTION
### What's this PR do?

This pull request [updates the prettier config](https://github.com/DoSomething/aurora/commit/2fc9e18521bf2a8cf0771ec0527b979e562fa2e7) in `package.json` to specify the PHP version used by the app (when we upgrade to 7.4 on this app, lets also update for Prettier).

This setting allows Prettier to also consider new syntax available in the newer PHP versions and format accordingly. The updates that occurred in this PR were related to a new rule that allows for trailing commas in function calls which came with PHP 7.3.

### How should this be reviewed?

👀  mostly for the config setting in `package.json`; the rest is all automated formatting!

### Relevant tickets

References [Pivotal #174412695](https://www.pivotaltracker.com/story/show/174412695).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
