### PR TITLE
Add Clubs Fields

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -116,6 +116,9 @@ class UsersController extends Controller
             $input['feature_flags'] = [];
         }
 
+        // The Club ID needs to be an integer.
+        $input['club_id'] = isset($input['club_id']) ? (int) $input['club_id'] : null;
+
         $this->northstar->updateUser($user->id, $input);
 
         return redirect()

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -94,6 +94,10 @@
               {!! Form::text('school_id', NULL, ['class' => 'text-field']) !!}
           </div>
           <div class="form-item -padded">
+              {!! Form::label('club_id', 'Club ID', ['class' => 'field-label']) !!}
+              {!! Form::text('club_id', NULL, ['class' => 'text-field']) !!}
+          </div>
+          <div class="form-item -padded">
               {!! Form::label('email_subscription_topics', 'Email Subscription Topics', ['class' => 'field-label']) !!}
                   <div>
                     {!! Form::checkbox('email_subscription_topics[]', 'community') !!}
@@ -110,6 +114,10 @@
                   <div>
                     {!! Form::checkbox('email_subscription_topics[]', 'scholarships') !!}
                     {!! Form::label('scholarships', 'scholarships') !!}
+                  </div>
+                  <div>
+                    {!! Form::checkbox('email_subscription_topics[]', 'clubs') !!}
+                    {!! Form::label('clubs', 'clubs') !!}
                   </div>
 
           </div>

--- a/resources/views/users/partials/field.blade.php
+++ b/resources/views/users/partials/field.blade.php
@@ -1,2 +1,2 @@
 <dt>{{ $label ?? Str::title($field) }}:</dt>
-<dd>{{ $user->{$field} ?? '&mdash;' }}</dd>
+<dd>{{ $user->{$field} ?? '—' }}</dd>

--- a/resources/views/users/partials/interests.blade.php
+++ b/resources/views/users/partials/interests.blade.php
@@ -1,1 +1,1 @@
-<dt>Cause Interests:</dt><dd>{{ $user->causes ? implode(",  ",$user->causes) : '&mdash;'}}</dd>
+<dt>Cause Interests:</dt><dd>{{ $user->causes ? implode(",  ",$user->causes) : '—'}}</dd>

--- a/resources/views/users/partials/profile.blade.php
+++ b/resources/views/users/partials/profile.blade.php
@@ -11,6 +11,7 @@
     @include('users.partials.sensitive-field', ['field' => 'birthdate', 'preview_field' => 'age', 'preview_suffix' => ' years old'])
     @include('users.partials.field', ['label' => 'Voter Registration Status', 'field' => 'voter_registration_status'])
     @include('users.partials.sensitive-field', ['label' => 'School ID', 'preview_field' => 'school_id_preview', 'field' => 'school_id'])
+    @include('users.partials.field', ['label' => 'Club ID', 'field' => 'club_id'])
 </div>
 <div class="profile-section">
     <h4>Address:</h4>

--- a/resources/views/users/partials/subscriptions.blade.php
+++ b/resources/views/users/partials/subscriptions.blade.php
@@ -1,5 +1,5 @@
-<dt>SMS Status:</dt><dd>{{ $user->sms_status ?? '&mdash;' }}</dd>
+<dt>SMS Status:</dt><dd>{{ $user->sms_status ?? '—' }}</dd>
 <dt>SMS Paused:</dt><dd>{{ $user->sms_paused ? '✔' : '✘' }}</dd>
-<dt>SMS Subscription Topics:</dt><dd>{{ $user->sms_subscription_topics ? implode(",  ",$user->sms_subscription_topics) : '&mdash;'}}</dd>
+<dt>SMS Subscription Topics:</dt><dd>{{ $user->sms_subscription_topics ? implode(",  ",$user->sms_subscription_topics) : '—'}}</dd>
 <dt>Email Subscription Status:</dt><dd>{{ $user->email_subscription_status ? '✔' : '✘' }}</dd>
-<dt>Email Subscription Topics:</dt><dd>{{ $user->email_subscription_topics ? implode(",  ",$user->email_subscription_topics) : '&mdash;'}}</dd>
+<dt>Email Subscription Topics:</dt><dd>{{ $user->email_subscription_topics ? implode(",  ",$user->email_subscription_topics) : '—'}}</dd>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -20,10 +20,10 @@
                 @include('layout.errors')
                 <dt>Source:</dt>
                 <dd>
-                    {{ $user->source ?? '&mdash;' }}
+                    {{ $user->source ?? '—' }}
                     <span class="footnote">({{ $user->source_detail ?? 'N/A' }})</span>
                 </dd>
-                <dt>Feature Flags:</dt><dd>{{ isset($user->feature_flags) ? json_encode($user->feature_flags) :  '&mdash;'}}</dd>
+                <dt>Feature Flags:</dt><dd>{{ isset($user->feature_flags) ? json_encode($user->feature_flags) :  '—'}}</dd>
                 @include('users.partials.field', ['field' => 'role'])
             </div>
             <div class="container__block -half profile-settings">


### PR DESCRIPTION
### What's this PR do?

This pull request adds the new `club_id` user attribute (https://github.com/DoSomething/northstar/pull/1046) and the `clubs` email subscription topic (https://github.com/DoSomething/northstar/pull/1048) to the user show & edit views.

While we were here, it also addresses [Pivotal #174585290](https://www.pivotaltracker.com/n/projects/2328687/stories/174585290) where `&mdash;` _within strings_ were being rendered onto the page. We update this by simply replacing the encoding with the literal `—` character.

### How should this be reviewed?
👀 

### Relevant tickets

References [Pivotal #174106253](https://www.pivotaltracker.com/story/show/174106253).
References [Pivotal #174585290](https://www.pivotaltracker.com/n/projects/2328687/stories/174585290).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/92261304-37b85d80-eea7-11ea-8163-7ff972fcc268.png)
![image](https://user-images.githubusercontent.com/12417657/92261331-41da5c00-eea7-11ea-9059-0ad570f227bb.png)

