### PR TITLE
Link To User's Club in Rogue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ FASTLY_API_KEY=
 FASTLY_TABLE_REDIRECTS=
 FASTLY_TABLE_REDIRECT_TYPES=
 
+ROGUE_URL=https://rogue.test
+
 CUSTOMER_IO_PROFILE_URL=https://fly.customer.io/env/63547/people
-ROGUE_PROFILE_URL=https://rogue.test/users
 GAMBIT_PROFILE_URL=https://gambit-admin-staging.herokuapp.com/users

--- a/config/services.php
+++ b/config/services.php
@@ -46,10 +46,7 @@ return [
     ],
 
     'rogue' => [
-        'profile_url' => env(
-            'ROGUE_PROFILE_URL',
-            'https://activity.dosomething.org/users',
-        ),
+        'url' => env('ROGUE_URL', 'https://activity.dosomething.org'),
     ],
 
     'ses' => [

--- a/resources/views/users/partials/profile.blade.php
+++ b/resources/views/users/partials/profile.blade.php
@@ -11,7 +11,17 @@
     @include('users.partials.sensitive-field', ['field' => 'birthdate', 'preview_field' => 'age', 'preview_suffix' => ' years old'])
     @include('users.partials.field', ['label' => 'Voter Registration Status', 'field' => 'voter_registration_status'])
     @include('users.partials.sensitive-field', ['label' => 'School ID', 'preview_field' => 'school_id_preview', 'field' => 'school_id'])
-    @include('users.partials.field', ['label' => 'Club ID', 'field' => 'club_id'])
+
+    <dt>Club ID:</dt>
+    <dd>
+        @if ($user->club_id)
+            <a href="{{ config('services.rogue.url') }}/clubs/{{ $user->club_id }}">
+                {{$user->club_id}}
+            </a>
+        @else
+            —
+        @endif
+    </dd>
 </div>
 <div class="profile-section">
     <h4>Address:</h4>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -79,7 +79,7 @@
                         <a href="{{ config('services.gambit.profile_url') }}/{{ $user->id }}">Gambit</a>
                     </li>
                     <li>
-                        <a href="{{ config('services.rogue.profile_url') }}/{{ $user->id }}">Rogue</a>
+                        <a href="{{ config('services.rogue.url') }}/users/{{ $user->id }}">Rogue</a>
                     </li>
             </div>
         </div>


### PR DESCRIPTION
### What's this PR do?

This pull request links to a user's club in Rogue if available.

https://github.com/DoSomething/aurora/commit/3d1c17a023dc5f6989b77bb355c8c6038867d7c4 replaces the `ROGUE_PROFILE_URL` with a `ROGUE_URL`, and instead inlines the profile path directly. We seem to only use this in one spot, so the benefit of the general `ROGUE_URL` seems like a good tradeoff. (I opted not to maintain the additional `ROGUE_PROFILE_URL` since that seemed like overkill).

### How should this be reviewed?`
I'd love feedback on if this approach re env variables makes sense.

And if the actual link implementation makes sense, this could be neat to extract into a partial and apply for the users school ID field as well.

### Any background context you want to provide?
This should make the admin experience a lot more convenient when dealing with user clubs.

### Relevant tickets

References [Pivotal #174586698](https://www.pivotaltracker.com/story/show/174586698).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.


<img width="1552" alt="Screen Shot 2020-10-16 at 3 19 46 PM" src="https://user-images.githubusercontent.com/12417657/96300140-13ca5a80-0fc3-11eb-8bc4-513e1b54c3dd.png">
